### PR TITLE
Fixed calendar showing only one event and time zone issue

### DIFF
--- a/lib/Calendar.dart
+++ b/lib/Calendar.dart
@@ -11,7 +11,7 @@ import 'package:table_calendar/table_calendar.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:connect_plus/Navbar.dart';
 import 'package:connect_plus/EventWidget.dart';
-
+import 'package:intl/intl.dart';
 class Calendar extends StatefulWidget {
   @override
   _CalendarState createState() => _CalendarState();
@@ -39,19 +39,19 @@ class _CalendarState extends State<Calendar> {
   }
 
   void getEvents() async {
+    getActivities();
     var events = await WebAPI.getEvents();
     if (this.mounted) {
       for (var event in events) {
-        var date = DateTime.parse(event.startDate.toString());
-        if (_events[date] != null)
-          _events[date].add(event);
+        var date = DateTime.parse(DateFormat('yyyy-MM-dd').format(event.startDate));
+        if (_all[date] != null)
+          _all[date].add(event);
         else
-          _events[date] = [event];
+          _all[date] = [event];
       }
       setState(() {
-        _all.addAll(_events);
       });
-      getActivities();
+      
     }
   }
 
@@ -60,7 +60,7 @@ class _CalendarState extends State<Calendar> {
     if (this.mounted) {
       for (var activity in activities) {
         activity.recurrenceDates.forEach((element) {
-          var date = DateTime.parse(element.toString());
+          var date = DateTime.parse(DateFormat('yyyy-MM-dd').format(element));
           if (_activities[date] != null)
             _activities[date].add(activity);
           else
@@ -78,17 +78,19 @@ class _CalendarState extends State<Calendar> {
     var webinars = await WebAPI.getWebinars();
     if (this.mounted) {
       for (var webinar in webinars) {
-        var date = DateTime.parse(webinar.startDate.toString());
-        if (_webinars[date] != null)
-          _webinars[date].add(webinar);
+        var date = DateTime.parse(DateFormat('yyyy-MM-dd').format(webinar.startDate));
+        if (_all[date] != null)
+          _all[date].add(webinar);
         else
-          _webinars[date] = [webinar];
+          _all[date] = [webinar];
       }
       setState(() {
-        _all.addAll(_webinars);
       });
     }
   }
+
+
+
 
   @override
   Widget build(BuildContext context) {

--- a/lib/models/activity.dart
+++ b/lib/models/activity.dart
@@ -63,9 +63,9 @@ class Activity {
         : null;
 
     endDate =
-        json['endDate'] != null ? DateTime.parse((json['endDate'])) : null;
+        json['endDate'] != null ? DateTime.parse((json['endDate'])).toLocal() : null;
     startDate =
-        json['startDate'] != null ? DateTime.parse((json['startDate'])) : null;
+        json['startDate'] != null ? DateTime.parse((json['startDate'])).toLocal() : null;
     createdAt =
         json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
     updatedAt =

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -45,9 +45,9 @@ class Event {
     venue = json['venue'];
     onBehalfOf = json['onBehalfOf'];
     endDate =
-        json['endDate'] != null ? DateTime.parse((json['endDate'])) : null;
+        json['endDate'] != null ? DateTime.parse((json['endDate'])).toLocal() : null;
     startDate =
-        json['startDate'] != null ? DateTime.parse((json['startDate'])) : null;
+        json['startDate'] != null ? DateTime.parse((json['startDate'])).toLocal() : null;
     createdAt =
         json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
     updatedAt =

--- a/lib/models/webinar.dart
+++ b/lib/models/webinar.dart
@@ -44,7 +44,7 @@ class Webinar {
     isRecorded = json['isRecorded'];
     duration = double.parse(json['Duration'].toString());
     startDate =
-        json['startDate'] != null ? DateTime.parse((json['startDate'])) : null;
+        json['startDate'] != null ? DateTime.parse((json['startDate'])).toLocal() : null;
     createdAt =
         json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
     updatedAt =


### PR DESCRIPTION
## What?
I've Fixed the calendar as each cell was showing only one event or webinar. Also, fixed the timezone issue when calling the API from 'Strapi' the time was being called in UTC timezone from the backend.
## Why?
The user would never know about some events if they share the same day with other event, which is highly likely as there are recurring events, so some events would share the same day.

Also, with the time being fetched from Strapi in UTC timezone that the user has no option to change the timezone.
## How?
The `_all` list was being overwritten each time `getEnvets` or `getWebinars` or `getActivities` was called. So I changed the way of appending in this list in each one of the three functions in order not to ignore the previous appends.

Modified `Event`, `Activity` and `Webinar` Classes to fetch the time according to the local timezone of the device. Which is a good practice that even if the problem from Strapi was solved in the future this wouldn't need another modification on the code.  

