### PR TITLE
Image Caching for better network performance

### DIFF
--- a/lib/Activities.dart
+++ b/lib/Activities.dart
@@ -10,6 +10,7 @@ import 'package:filter_list/filter_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:localstorage/localstorage.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class Activities extends StatefulWidget {
   Activities({
@@ -110,7 +111,11 @@ class MyActivitiesPageState extends State<Activities>
       final imageURL = WebAPI.baseURL + featuruedActivity.poster.url;
       return FittedBox(
         fit: BoxFit.fill,
-        child: Image.network(imageURL),
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl:
+            imageURL,
+        ),
       );
     } catch (Exception) {
       return Scaffold(body: ImageRotate());
@@ -122,7 +127,13 @@ class MyActivitiesPageState extends State<Activities>
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.width *
           0.5, // otherwise the logo will be tiny
-      child: FittedBox(fit: BoxFit.fill, child: Image.network(imageUrl)),
+      child: FittedBox(fit: BoxFit.fill,
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl:
+            imageUrl,
+        ),
+      ),
     );
   }
 

--- a/lib/ActivityWidget.dart
+++ b/lib/ActivityWidget.dart
@@ -13,7 +13,7 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'dart:typed_data';
 import 'widgets/Indicator.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class ActivityWidget extends StatefulWidget {
   ActivityWidget({Key key, @required this.activity}) : super(key: key);
 
@@ -60,7 +60,14 @@ class _ActivityState extends State<ActivityWidget>
 
   Widget urlToImage(String imageURL) {
     return Expanded(
-        child: FittedBox(fit: BoxFit.contain, child: Image.network(imageURL)));
+        child: FittedBox(fit: BoxFit.contain,
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+              imageURL,
+          ),
+        )
+    );
   }
 
   List<Widget> activitiesByERG() {
@@ -114,7 +121,11 @@ class _ActivityState extends State<ActivityWidget>
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: Image.network(WebAPI.baseURL + activity.poster.url),
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+              WebAPI.baseURL + activity.poster.url,
+          ),
         )
       ],
     );

--- a/lib/Carousel.dart
+++ b/lib/Carousel.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_options.dart';
 import 'package:carousel_slider/carousel_slider.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 final List<String> imgList = [
   'https://mainvibes.com/wp-content/uploads/2020/05/Party.jpeg',
   'https://identity-mag.com/wp-content/uploads/2020/01/My-Post-19.jpg',
@@ -19,7 +19,14 @@ final List<Widget> imageSliders = imgList
                 borderRadius: BorderRadius.all(Radius.circular(5.0)),
                 child: Stack(
                   children: <Widget>[
-                    Image.network(item, fit: BoxFit.cover, width: 1000.0),
+                    CachedNetworkImage(
+                      placeholder: (context, url) => CircularProgressIndicator(),
+                      imageUrl:
+                        item,
+                      fit: BoxFit.cover,
+                      width: 1000.0
+                    ),
+                    //Image.network(item, fit: BoxFit.cover, width: 1000.0),
                     Positioned(
                       bottom: 0.0,
                       left: 0.0,

--- a/lib/EventWidget.dart
+++ b/lib/EventWidget.dart
@@ -9,7 +9,7 @@ import 'Navbar.dart';
 import 'widgets/Utils.dart';
 import 'dart:convert';
 import 'widgets/Indicator.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class EventWidget extends StatefulWidget {
   EventWidget({Key key, @required this.event}) : super(key: key);
 
@@ -60,7 +60,14 @@ class _EventState extends State<EventWidget> with TickerProviderStateMixin {
 
   Widget urlToImage(String imageURL) {
     return Expanded(
-        child: FittedBox(fit: BoxFit.contain, child: Image.network(imageURL)));
+        child: FittedBox(fit: BoxFit.contain,
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+            imageURL,
+          ),
+        )
+    );
   }
 
   List<Widget> eventsByERG() {
@@ -114,7 +121,11 @@ class _EventState extends State<EventWidget> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: Image.network(WebAPI.baseURL + event.poster.url),
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+              WebAPI.baseURL + event.poster.url,
+          ),
         )
       ],
     );

--- a/lib/Events.dart
+++ b/lib/Events.dart
@@ -12,6 +12,7 @@ import 'package:connect_plus/EventWidget.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:localstorage/localstorage.dart';
 import 'dart:math';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class Events extends StatefulWidget {
   Events({
@@ -142,7 +143,11 @@ class MyEventsPageState extends State<Events>
       final imageURL = WebAPI.baseURL + featuredEvent.poster.url;
       return FittedBox(
         fit: BoxFit.fill,
-        child: Image.network(imageURL),
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl:
+          imageURL,
+        ),
       );
     } catch (Exception) {
       return Scaffold(
@@ -153,10 +158,16 @@ class MyEventsPageState extends State<Events>
 
   Widget urlToImage(String imageUrl) {
     return SizedBox(
-      width: MediaQuery.of(context).size.width,
-      height: MediaQuery.of(context).size.width *
-          0.50, // otherwise the logo will be tiny
-      child: FittedBox(fit: BoxFit.fill, child: Image.network(imageUrl)),
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.width *
+            0.50, // otherwise the logo will be tiny
+        child: FittedBox(fit: BoxFit.fill,
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+            imageUrl,
+          ),
+        )
     );
   }
 
@@ -223,14 +234,14 @@ class MyEventsPageState extends State<Events>
         selectedTextBackgroundColor: Utils.header,
         searchFieldHintText: "Search Here",
         selectedTextList: selectedCountList, onApplyButtonClick: (list) {
-      if (list != null) {
-        setState(() {
-          selectedCountList = List.from(list);
-          filterData();
+          if (list != null) {
+            setState(() {
+              selectedCountList = List.from(list);
+              filterData();
+            });
+          }
+          Navigator.pop(context);
         });
-      }
-      Navigator.pop(context);
-    });
   }
 
   @override
@@ -310,70 +321,70 @@ class MyEventsPageState extends State<Events>
                     child: Container(
                         child: SingleChildScrollView(
                             child: Column(children: <Widget>[
-                      SizedBox(
-                        height: 10,
-                      ),
-                      ListView(
-                        shrinkWrap: true,
-                        physics: ScrollPhysics(),
-                        children: mapIndexed(_filteredData, (index, event) {
-                          return Center(
-                              child: SizedBox(
-                            width: width * 0.8,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              mainAxisSize: MainAxisSize.min,
-                              children: <Widget>[
-                                Text(
-                                  event.name.toString(),
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                      fontSize: 23,
-                                      color: Colors.black87,
-                                      fontWeight: FontWeight.w500),
-                                ),
-                                SizedBox(
-                                  height: 5,
-                                ),
-                                Card(
-                                    elevation: 7.0,
-                                    clipBehavior: Clip.antiAlias,
-                                    margin: EdgeInsets.all(12.0),
-                                    shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.all(
-                                            Radius.circular(10.0))),
-                                    child: InkWell(
-                                      child: urlToImage(
-                                          WebAPI.baseURL + event.poster.url),
-                                      onTap: () {
-                                        if (event.runtimeType == Event) {
-                                          Navigator.push(
-                                            context,
-                                            MaterialPageRoute(
-                                              builder: (context) =>
-                                                  EventWidget(event: event),
+                              SizedBox(
+                                height: 10,
+                              ),
+                              ListView(
+                                shrinkWrap: true,
+                                physics: ScrollPhysics(),
+                                children: mapIndexed(_filteredData, (index, event) {
+                                  return Center(
+                                      child: SizedBox(
+                                        width: width * 0.8,
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.center,
+                                          mainAxisSize: MainAxisSize.min,
+                                          children: <Widget>[
+                                            Text(
+                                              event.name.toString(),
+                                              textAlign: TextAlign.center,
+                                              style: TextStyle(
+                                                  fontSize: 23,
+                                                  color: Colors.black87,
+                                                  fontWeight: FontWeight.w500),
                                             ),
-                                          );
-                                        } else {
-                                          Navigator.push(
-                                            context,
-                                            MaterialPageRoute(
-                                              builder: (context) =>
-                                                  WebinarWidget(webinar: event),
+                                            SizedBox(
+                                              height: 5,
                                             ),
-                                          );
-                                        }
-                                      },
-                                    )),
-                                SizedBox(
-                                  height: 30,
-                                )
-                              ],
-                            ),
-                          ));
-                        }).toList(),
-                      ),
-                    ]))))));
+                                            Card(
+                                                elevation: 7.0,
+                                                clipBehavior: Clip.antiAlias,
+                                                margin: EdgeInsets.all(12.0),
+                                                shape: RoundedRectangleBorder(
+                                                    borderRadius: BorderRadius.all(
+                                                        Radius.circular(10.0))),
+                                                child: InkWell(
+                                                  child: urlToImage(
+                                                      WebAPI.baseURL + event.poster.url),
+                                                  onTap: () {
+                                                    if (event.runtimeType == Event) {
+                                                      Navigator.push(
+                                                        context,
+                                                        MaterialPageRoute(
+                                                          builder: (context) =>
+                                                              EventWidget(event: event),
+                                                        ),
+                                                      );
+                                                    } else {
+                                                      Navigator.push(
+                                                        context,
+                                                        MaterialPageRoute(
+                                                          builder: (context) =>
+                                                              WebinarWidget(webinar: event),
+                                                        ),
+                                                      );
+                                                    }
+                                                  },
+                                                )),
+                                            SizedBox(
+                                              height: 30,
+                                            )
+                                          ],
+                                        ),
+                                      ));
+                                }).toList(),
+                              ),
+                            ]))))));
     } catch (err) {
       return Scaffold(
         body: ImageRotate(),
@@ -386,7 +397,7 @@ class MyEventsPageState extends State<Events>
     final filter = searchAll
         .where(
           (entry) => entry.name.toLowerCase().startsWith(pattern.toLowerCase()),
-        )
+    )
         .toList();
     return filter;
   }

--- a/lib/EventsVariable.dart
+++ b/lib/EventsVariable.dart
@@ -10,7 +10,7 @@ import 'package:intl/intl.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:connect_plus/EventWidget.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class EventsVariables extends StatefulWidget {
   EventsVariables({Key key, @required this.events, @required this.webinars})
       : super(key: key);
@@ -212,10 +212,12 @@ class Single_Event extends StatelessWidget {
                         ]),
                       ),
                     ),
-                    child: Image.network(
-                      WebAPI.baseURL + event.poster.url,
-                      fit: BoxFit.fill,
-                    )),
+                    child: CachedNetworkImage(
+                      placeholder: (context, url) => CircularProgressIndicator(),
+                      imageUrl:
+                        WebAPI.baseURL + event.poster.url,
+                    ),
+                ),
               ),
             ),
           ),

--- a/lib/OfferVariables.dart
+++ b/lib/OfferVariables.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:flutter/cupertino.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class OfferVariables extends StatefulWidget {
   OfferVariables({Key key, @required this.offers}) : super(key: key);
 
@@ -151,10 +151,12 @@ class Single_Offer extends StatelessWidget {
                       ),
                     ),
                   ),
-                  child: Image.network(
-                    WebAPI.baseURL + offer.logo.url,
-                    fit: BoxFit.fill,
-                  )),
+                  child: CachedNetworkImage(
+                    placeholder: (context, url) => CircularProgressIndicator(),
+                    imageUrl:
+                      WebAPI.baseURL + offer.logo.url,
+                  ),
+              ),
             ),
           ),
         ),

--- a/lib/OfferWidget.dart
+++ b/lib/OfferWidget.dart
@@ -11,7 +11,7 @@ import 'package:localstorage/localstorage.dart';
 import 'Navbar.dart';
 import 'widgets/Utils.dart';
 import 'widgets/Indicator.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class OfferWidget extends StatefulWidget {
   OfferWidget({
     Key key,
@@ -75,7 +75,11 @@ class _OfferState extends State<OfferWidget> with TickerProviderStateMixin {
         width: MediaQuery.of(context)
             .size
             .width, // otherwise the logo will be tiny
-        child: Image.network(imageURL),
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl:
+            imageURL,
+        ),
       ),
     );
   }
@@ -150,7 +154,11 @@ class _OfferState extends State<OfferWidget> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: Image.network(WebAPI.baseURL + widget.offer.logo.url),
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+            WebAPI.baseURL + widget.offer.logo.url,
+          ),
         )
       ],
     );

--- a/lib/Offers.dart
+++ b/lib/Offers.dart
@@ -9,7 +9,7 @@ import 'package:localstorage/localstorage.dart';
 import 'package:connect_plus/OfferWidget.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:connect_plus/utils/map_indexed.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class Offers extends StatefulWidget {
   Offers({Key key, this.offerCategory}) : super(key: key);
 
@@ -88,7 +88,11 @@ class _OffersState extends State<Offers> {
       setState(() {
         recent.forEach((element) {
           element.highlight.forEach((h) {
-            recentOffers.add(Image.network(WebAPI.baseURL + h.url));
+            recentOffers.add(CachedNetworkImage(
+              placeholder: (context, url) => CircularProgressIndicator(),
+              imageUrl:
+              WebAPI.baseURL + h.url,
+            ));
           });
         });
         loadedHighlights = true;
@@ -124,7 +128,13 @@ class _OffersState extends State<Offers> {
     return Expanded(
       child: SizedBox(
         width: 250, // otherwise the logo will be tiny
-        child: FittedBox(fit: BoxFit.contain, child: Image.network(imageURL)),
+        child: FittedBox(fit: BoxFit.contain,
+            child: CachedNetworkImage(
+              placeholder: (context, url) => CircularProgressIndicator(),
+              imageUrl:
+                imageURL,
+          )
+        ),
       ),
     );
   }
@@ -134,7 +144,11 @@ class _OffersState extends State<Offers> {
       final url = WebAPI.baseURL + offers[randIndexOffer].logo.url;
       return FittedBox(
         fit: BoxFit.contain,
-        child: Image.network(url),
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl:
+            url,
+        ),
       );
     } catch (Exception) {
       print(Exception);

--- a/lib/WebinarWidget.dart
+++ b/lib/WebinarWidget.dart
@@ -11,7 +11,7 @@ import 'widgets/Utils.dart';
 import 'dart:convert';
 import 'widgets/Indicator.dart';
 import 'package:url_launcher/url_launcher.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class WebinarWidget extends StatefulWidget {
   WebinarWidget({Key key, @required this.webinar}) : super(key: key);
 
@@ -55,7 +55,11 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
     return Expanded(
       child: SizedBox(
         width: 250, // otherwise the logo will be tiny
-        child: Image.network(imageURL),
+        child: CachedNetworkImage(
+          placeholder: (context, url) => CircularProgressIndicator(),
+          imageUrl:
+          imageURL,
+        ),
       ),
     );
   }
@@ -92,7 +96,7 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
                       ergwebinar.name,
                       textAlign: TextAlign.center,
                       style:
-                          TextStyle(fontSize: size * 35, color: Utils.header),
+                      TextStyle(fontSize: size * 35, color: Utils.header),
                     ),
                   )
                 ],
@@ -130,13 +134,13 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
   }
 
   Widget _icon(
-    IconData icon, {
-    Color color = Utils.iconColor,
-    double size = 20,
-    double padding = 10,
-    bool isOutLine = false,
-    Function onPressed,
-  }) {
+      IconData icon, {
+        Color color = Utils.iconColor,
+        double size = 20,
+        double padding = 10,
+        bool isOutLine = false,
+        Function onPressed,
+      }) {
     return Container(
       height: 40,
       width: 40,
@@ -163,7 +167,11 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: Image.network(WebAPI.baseURL + webinar.poster.url),
+          child: CachedNetworkImage(
+            placeholder: (context, url) => CircularProgressIndicator(),
+            imageUrl:
+            WebAPI.baseURL + webinar.poster.url,
+          ),
         )
       ],
     );

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -11,8 +11,8 @@ import 'package:connect_plus/Navbar.dart';
 import 'package:connect_plus/Events.dart';
 import 'package:connect_plus/OfferVariables.dart';
 import 'package:connect_plus/Offers.dart';
-
 import 'EventsVariable.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class MyHomePage extends StatefulWidget {
   MyHomePage({Key key, this.title}) : super(key: key);
@@ -90,7 +90,12 @@ class _MyHomePageState extends State<MyHomePage> {
       setState(() {
         recent.forEach((element) {
           element.highlight.forEach((h) {
-            recentEvents.add(Image.network(WebAPI.baseURL + h.url));
+
+            recentEvents.add(CachedNetworkImage(
+              placeholder: (context, url) => CircularProgressIndicator(),
+              imageUrl:
+                WebAPI.baseURL + h.url,
+            ));
           });
         });
         highlightsLoaded = true;

--- a/lib/included.dart
+++ b/lib/included.dart
@@ -6,7 +6,7 @@ import 'package:connect_plus/widgets/Utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:connect_plus/Navbar.dart';
-
+import 'package:cached_network_image/cached_network_image.dart';
 class Included extends StatefulWidget {
   Included({Key key, this.title}) : super(key: key);
   final String title;
@@ -112,9 +112,13 @@ class _IncludedState extends State<Included> {
                       child: SizedBox(
                         height: MediaQuery.of(context).size.height * 0.3,
                         width: MediaQuery.of(context).size.width * 0.65,
-                        child: Image.network(
-                            WebAPI.baseURL + ergsList[index].poster.url),
-                      )),
+                        child: CachedNetworkImage(
+                          placeholder: (context, url) => CircularProgressIndicator(),
+                          imageUrl:
+                            WebAPI.baseURL + ergsList[index].poster.url,
+                        ),
+                      ),
+                  ),
                   SizedBox(
                     height: 20,
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0-nullsafety.1"
   basics:
     dependency: transitive
     description:
@@ -35,7 +35,14 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.1"
   carousel_pro:
     dependency: "direct main"
     description:
@@ -50,27 +57,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -92,6 +106,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0-nullsafety.1"
   ffi:
     dependency: transitive
     description:
@@ -174,20 +195,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   flutter_cache_manager:
     dependency: transitive
     description:
       name: flutter_cache_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "2.1.2"
   flutter_cached_pdfview:
     dependency: "direct main"
     description:
       name: flutter_cached_pdfview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3+4"
+    version: "0.2.9"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -300,7 +328,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.19"
   intl:
     dependency: "direct main"
     description:
@@ -335,14 +363,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   modal_progress_hud:
     dependency: "direct main"
     description:
@@ -357,6 +385,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   package_info:
     dependency: "direct main"
     description:
@@ -377,14 +412,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.18"
+    version: "1.6.28"
   path_provider_linux:
     dependency: transitive
     description:
@@ -426,7 +461,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "3.1.0"
   platform:
     dependency: transitive
     description:
@@ -557,7 +592,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   splashscreen:
     dependency: "direct main"
     description:
@@ -571,35 +606,35 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1+1"
+    version: "1.3.2+4"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2+1"
+    version: "1.0.3+3"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   synchronized:
     dependency: transitive
     description:
@@ -620,14 +655,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.19-nullsafety.2"
   time_machine:
     dependency: "direct main"
     description:
@@ -641,7 +676,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0-nullsafety.3"
   url_launcher:
     dependency: "direct main"
     description:
@@ -690,7 +725,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   win32:
     dependency: transitive
     description:
@@ -711,7 +746,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "4.5.1"
   yaml:
     dependency: transitive
     description:
@@ -720,5 +755,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.8.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.10.2 <2.11.0"
+  flutter: ">=1.22.2 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,7 +57,8 @@ dependencies:
   time_machine: ^0.9.13
   firebase_auth: ^0.18.4+1
   firebase_remote_config: "^0.4.3"
-
+  cached_network_image: ^2.5.1
+  #cached_network_image: ^2.5.1
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3


### PR DESCRIPTION
## What?
Fixed Loading time for image as it was taking so much time.

## Why?
It was not only about the image taking too long to load but this was affecting the whole performance of the app.
as every time the app is loaded it needed to fetch all the images in the homepage or in any page so this caused the app to keep the loading screen so long.
## How?
By using `cached_network_image` instead of `network.image`. It stores and retrieves files using the `flutter_cache_manager`. so the images doesn't need to be loaded every time the page is refreshed.

for more info about the image caching :
https://pub.dev/packages/cached_network_image
