### PR TITLE
Feature 177624759 announcement list with filter

### DIFF
--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -7,6 +7,7 @@ import 'package:connect_plus/widgets/Utils.dart';
 import 'package:filter_list/filter_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:connect_plus/announcement_widget.dart';
 
 class Announcements extends StatefulWidget {
   @override
@@ -148,7 +149,13 @@ class AnnouncementCard extends StatelessWidget {
           child: InkWell(
             child: AnnouncementImage(announcement: announcement),
             onTap: () {
-              //TODO: Navigate to announcement widget
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => AnnouncementWidget(
+                    announcement: announcement,
+                  ),
+                ),
+              );
             },
           ),
         ),
@@ -235,7 +242,12 @@ class SearchBar extends StatelessWidget {
           );
         },
         onSuggestionSelected: (announcement) {
-          //TODO navigate to announcement widget
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) =>
+                  AnnouncementWidget(announcement: announcement),
+            ),
+          );
         },
       ),
     );

--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -1,0 +1,260 @@
+import 'dart:async';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/models/announcement.dart';
+import 'package:connect_plus/services/web_api.dart';
+import 'package:connect_plus/widgets/Utils.dart';
+import 'package:filter_list/filter_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+
+class Announcements extends StatefulWidget {
+  @override
+  _AnnouncementsState createState() => _AnnouncementsState();
+}
+
+class _AnnouncementsState extends State<Announcements> {
+  List<String> onBehalfOfFilter;
+
+  bool filter(Announcement announcement) {
+    return onBehalfOfFilter.contains(announcement.onBehalfOf);
+  }
+
+  Future<void> _showFilters(List<Announcement> announcements) async {
+    final selectedFilters = onBehalfOfFilter.isEmpty
+        ? announcements.map((a) => a.onBehalfOf).toList()
+        : onBehalfOfFilter;
+    return await FilterListDialog.display(
+      context,
+      allTextList: announcements.map((a) => a.onBehalfOf).toList(),
+      height: 480,
+      borderRadius: 20,
+      headlineText: "Select Announcements on Behalf of",
+      applyButonTextBackgroundColor: Utils.header,
+      allResetButonColor: Utils.header,
+      selectedTextBackgroundColor: Utils.header,
+      searchFieldHintText: "Search Here",
+      selectedTextList: selectedFilters,
+      onApplyButtonClick: (onBehalfOfFilterList) {
+        setState(() {
+          onBehalfOfFilter = onBehalfOfFilterList;
+        });
+        Navigator.pop(context);
+      },
+    );
+  }
+
+  Future<List<Announcement>> _getAnnouncements() async {
+    final announcements = await WebAPI.getUnexpiredAnnouncements();
+
+    if (onBehalfOfFilter == null) {
+      // will only run once
+      onBehalfOfFilter = announcements.map((a) => a.onBehalfOf).toList();
+    }
+    return announcements;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = MediaQuery.of(context).size;
+    return FutureBuilder<List<Announcement>>(
+      future: _getAnnouncements(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) return Scaffold(body: LoadingIndicator());
+        final List<Announcement> announcements = snapshot.data;
+        return Scaffold(
+          floatingActionButton: FloatingActionButton(
+            child: Icon(Icons.filter_list),
+            onPressed: () async {
+              await _showFilters(announcements);
+            },
+          ),
+          appBar: AppBar(
+            title: Text("Announcements"),
+            centerTitle: true,
+            bottom: PreferredSize(
+              child: SearchBar(
+                toSuggest: (pattern) {
+                  if (pattern == "") return null;
+                  return announcements
+                      .where((a) => filter(a) && a.name.startsWith(pattern))
+                      .take(5); // suggests only 5
+                },
+              ),
+              preferredSize: Size.fromHeight(kToolbarHeight + 10),
+            ),
+            flexibleSpace: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    Utils.secondaryColor,
+                    Utils.primaryColor,
+                  ],
+                  begin: Alignment.topRight,
+                  end: Alignment.bottomLeft,
+                ),
+              ),
+            ),
+          ),
+          body: Padding(
+            padding: EdgeInsets.only(
+              top: screen.height * 0.02,
+              bottom: screen.height * 0.02,
+              left: screen.width * 0.02,
+              right: screen.width * 0.02,
+            ),
+            child: ListView(
+              children: announcements.where(filter).map((announcement) {
+                return Center(
+                  child: SizedBox(
+                    width: screen.width * 0.8,
+                    child: AnnouncementCard(announcement: announcement),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class AnnouncementCard extends StatelessWidget {
+  const AnnouncementCard({
+    Key key,
+    @required this.announcement,
+  }) : super(key: key);
+
+  final Announcement announcement;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        AnnouncementName(announcement: announcement),
+        SizedBox(height: 5),
+        Card(
+          elevation: 7.0,
+          clipBehavior: Clip.antiAlias,
+          margin: EdgeInsets.all(12.0),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(
+              Radius.circular(10.0),
+            ),
+          ),
+          child: InkWell(
+            child: AnnouncementImage(announcement: announcement),
+            onTap: () {
+              //TODO: Navigate to announcement widget
+            },
+          ),
+        ),
+        SizedBox(height: 30),
+      ],
+    );
+  }
+}
+
+class AnnouncementImage extends StatelessWidget {
+  const AnnouncementImage({
+    Key key,
+    @required this.announcement,
+  }) : super(key: key);
+
+  final Announcement announcement;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      height: MediaQuery.of(context).size.width * 0.5,
+      child: CachedNetworkImage(
+        fit: BoxFit.fill,
+        placeholder: (context, url) => LoadingIndicator(),
+        imageUrl: WebAPI.baseURL + announcement.poster.url,
+      ),
+    );
+  }
+}
+
+class AnnouncementName extends StatelessWidget {
+  const AnnouncementName({
+    Key key,
+    @required this.announcement,
+  }) : super(key: key);
+
+  final Announcement announcement;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      announcement.name,
+      textAlign: TextAlign.center,
+      style: TextStyle(
+        fontSize: 23,
+        color: Colors.black87,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+  }
+}
+
+class SearchBar extends StatelessWidget {
+  final FutureOr<Iterable<Announcement>> Function(String pattern) toSuggest;
+
+  const SearchBar({Key key, @required this.toSuggest}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(20, 5, 20, 10),
+      child: TypeAheadField<Announcement>(
+        textFieldConfiguration: TextFieldConfiguration(
+          decoration: InputDecoration(
+            fillColor: Colors.white,
+            filled: true,
+            suffixIcon: Icon(Icons.search),
+            focusedBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Utils.header),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderSide: BorderSide(color: Utils.header),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            hintText: " Search ",
+          ),
+        ),
+        suggestionsCallback: toSuggest,
+        itemBuilder: (context, dynamic suggestedObject) {
+          return ListTile(
+            leading: Icon(Icons.announcement),
+            title: Text(suggestedObject.name),
+          );
+        },
+        onSuggestionSelected: (announcement) {
+          //TODO navigate to announcement widget
+        },
+      ),
+    );
+  }
+}
+
+class LoadingIndicator extends StatelessWidget {
+  const LoadingIndicator({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        height: 60,
+        width: 60,
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -1,4 +1,5 @@
 import 'package:carousel_pro/carousel_pro.dart';
+import 'package:connect_plus/announcements.dart';
 import 'package:connect_plus/models/event.dart';
 import 'package:connect_plus/models/offer.dart';
 import 'package:connect_plus/models/webinar.dart';
@@ -234,10 +235,17 @@ class _MyHomePageState extends State<MyHomePage> {
                       context,
                       MaterialPageRoute(builder: (context) => Events()),
                     );
-                  } else {
+                  } else if (view == 'Offers') {
                     Navigator.push(
                       context,
                       MaterialPageRoute(builder: (context) => Offers()),
+                    );
+                  } else if (view == 'Announcements') {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => Announcements(),
+                      ),
                     );
                   }
                 },

--- a/lib/services/web_api.dart
+++ b/lib/services/web_api.dart
@@ -488,4 +488,21 @@ class WebAPI {
 
     return announcements;
   }
+
+  /// Returns list of all announcements future or null deadlines
+  static Future<List<Announcement>> getUnexpiredAnnouncements() async {
+    final now = DateTime.now().toIso8601String();
+    final response = await get(
+      "$_announcementURL?_where[_or][0][deadline_gt]=$now&_where[_or][1][deadline_null]=true",
+    );
+    // TODO: Add this logic to a seperate transformer service
+    final List<dynamic> rawAnnouncements = json.decode(response.body);
+    final List<Announcement> announcements = [];
+    for (final announcementJson in rawAnnouncements) {
+      //if (announcement.fromJson(announcementJson).endDate.isAfter(DateTime.now()))
+      announcements.add(Announcement.fromJson(announcementJson));
+    }
+
+    return announcements;
+  }
 }


### PR DESCRIPTION
### Story Description
**Same as Webinars & Events Page**

As a user, I want to have a page where it displays all announcements in the cms that have not met their deadlines yet.

**Filtering**
- There should be an option for announcements to be filtered by onBehalfOf field
<img src="https://user-images.githubusercontent.com/41022464/115694243-f8208200-a360-11eb-9bcf-a94a1730c7d0.png" width=300>
###
<img src="https://user-images.githubusercontent.com/41022464/115694254-fb1b7280-a360-11eb-8802-dd1e707b8297.png" width=300>
###
<img src="https://user-images.githubusercontent.com/41022464/115694272-fe166300-a360-11eb-9375-d0e03cfa643d.png" width=300>



#### 
In addition, I've changed the homepage loading indicators from circular progress indicators to fading grey containers, I think the circular progress indicators introduced from the widget responsible for caching network images does not look good

#Old 
![old](https://user-images.githubusercontent.com/41022464/115695160-d378da00-a361-11eb-87a5-126c1792497d.gif)

#New
![new](https://user-images.githubusercontent.com/41022464/115695182-d7a4f780-a361-11eb-96ce-64aca2e20262.gif)




