### PR TITLE
Bugfix invalid links and missing announcements in drawer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ app.*.map.json
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 ios/Runner.xcodeproj/project.pbxproj
 ios/Runner.xcworkspace/contents.xcworkspacedata
+ios/Runner/GoogleService-Info.plist
+ios/Flutter/.last_build_id
 .env
 google-services.json
 launch.json

--- a/lib/Navbar.dart
+++ b/lib/Navbar.dart
@@ -1,5 +1,6 @@
 import 'package:connect_plus/Activities.dart';
 import 'package:connect_plus/aboutus.dart';
+import 'package:connect_plus/announcements.dart';
 import 'package:connect_plus/events.dart';
 import 'package:connect_plus/included.dart';
 import 'package:flutter/material.dart';
@@ -86,6 +87,16 @@ class NavDrawerState extends State<NavDrawer>
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => Events()),
+              )
+            },
+          ),
+          ListTile(
+            leading: Icon(Icons.announcement),
+            title: Text('Announcements'),
+            onTap: () => {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => Announcements()),
               )
             },
           ),

--- a/lib/Navbar.dart
+++ b/lib/Navbar.dart
@@ -3,6 +3,8 @@ import 'package:connect_plus/aboutus.dart';
 import 'package:connect_plus/announcements.dart';
 import 'package:connect_plus/events.dart';
 import 'package:connect_plus/included.dart';
+import 'package:connect_plus/injection_container.dart';
+import 'package:connect_plus/services/auth_service/auth_service.dart';
 import 'package:flutter/material.dart';
 import 'package:connect_plus/Profile.dart';
 import 'package:connect_plus/emergencyContact.dart';
@@ -151,11 +153,12 @@ class NavDrawerState extends State<NavDrawer>
           ListTile(
             leading: Icon(Icons.exit_to_app),
             title: Text('Logout'),
-            onTap: () => {
-              prefs.remove("token"),
+            onTap: () async {
+              await sl<AuthService>().logout();
+              await prefs.remove("token");
               Navigator.of(context).pushAndRemoveUntil(
                   MaterialPageRoute(builder: (context) => Login()),
-                  (Route<dynamic> route) => false)
+                  (Route<dynamic> route) => false);
             },
           ),
         ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  // TODO: move to injection container
   final Future<FirebaseApp> _initialization = Firebase.initializeApp();
   @override
   void initState() {

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -57,8 +57,9 @@ class Announcement {
         : null;
     id = json['id'];
     slider = json['slider'] ?? false;
-    trivia = json['trivia']; // will auto set to null
-    link = json['link']; // will auto set to null
+    trivia =
+        json['trivia'] == "" ? null : json['trivia']; // will auto set to null
+    link = json['link'] == "" ? null : json['link']; // will auto set to null
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -104,6 +104,7 @@ class AuthService {
   Future<String> resetPassword(String email) async {
     try {
       await _fbAuth.sendPasswordResetEmail(email: email);
+      return null;
     } catch (e) {
       print(e.toString());
       return e.toString();

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -109,6 +109,10 @@ class AuthService {
       return e.toString();
     }
   }
+
+  Future<void> logout() async {
+    return await _fbAuth.signOut();
+  }
 }
 
 enum AuthState {


### PR DESCRIPTION
## Fixed
- Trivia/details buttons on announcements appeared when the trivia/link fields had empty string values
- Logout from the drawer navigated to the login screen but did not logout the user

## Added
- Announcement tile in the drawer that navigates to the announcements list screen

<img src="https://user-images.githubusercontent.com/41022464/116223791-30083a80-a750-11eb-8fdb-ce5ca105be58.png" width=300>
