### PR TITLE
Added cached image box widget

### DIFF
--- a/lib/Activities.dart
+++ b/lib/Activities.dart
@@ -10,7 +10,7 @@ import 'package:filter_list/filter_list.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:localstorage/localstorage.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class Activities extends StatefulWidget {
   Activities({
@@ -111,11 +111,7 @@ class MyActivitiesPageState extends State<Activities>
       final imageURL = WebAPI.baseURL + featuruedActivity.poster.url;
       return FittedBox(
         fit: BoxFit.fill,
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl:
-            imageURL,
-        ),
+        child: CachedImageBox(imageurl: imageURL),
       );
     } catch (Exception) {
       return Scaffold(body: ImageRotate());
@@ -127,11 +123,10 @@ class MyActivitiesPageState extends State<Activities>
       width: MediaQuery.of(context).size.width,
       height: MediaQuery.of(context).size.width *
           0.5, // otherwise the logo will be tiny
-      child: FittedBox(fit: BoxFit.fill,
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl:
-            imageUrl,
+      child: FittedBox(
+        fit: BoxFit.fill,
+        child: CachedImageBox(
+          imageurl: imageUrl,
         ),
       ),
     );

--- a/lib/ActivityWidget.dart
+++ b/lib/ActivityWidget.dart
@@ -5,15 +5,9 @@ import 'package:connect_plus/widgets/ImageRotate.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'Navbar.dart';
 import 'widgets/Utils.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:http/http.dart' as http;
-import 'dart:convert';
-import 'dart:typed_data';
-import 'widgets/Indicator.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
+
 class ActivityWidget extends StatefulWidget {
   ActivityWidget({Key key, @required this.activity}) : super(key: key);
 
@@ -60,14 +54,12 @@ class _ActivityState extends State<ActivityWidget>
 
   Widget urlToImage(String imageURL) {
     return Expanded(
-        child: FittedBox(fit: BoxFit.contain,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-              imageURL,
-          ),
-        )
-    );
+        child: FittedBox(
+      fit: BoxFit.contain,
+      child: CachedImageBox(
+        imageurl: imageURL,
+      ),
+    ));
   }
 
   List<Widget> activitiesByERG() {
@@ -116,17 +108,15 @@ class _ActivityState extends State<ActivityWidget>
   }
 
   Widget _activityPoster() {
+    String imageUrl = WebAPI.baseURL + activity.poster.url;
     return Stack(
       alignment: Alignment.bottomCenter,
       children: <Widget>[
         SizedBox(
-          width: MediaQuery.of(context).size.width,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-              WebAPI.baseURL + activity.poster.url,
-          ),
-        )
+            width: MediaQuery.of(context).size.width,
+            child: CachedImageBox(
+              imageurl: imageUrl,
+            ))
       ],
     );
   }

--- a/lib/AnnouncementVariables.dart
+++ b/lib/AnnouncementVariables.dart
@@ -3,7 +3,7 @@ import 'package:connect_plus/models/announcement.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:connect_plus/services/web_api.dart';
 import 'announcement_widget.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class AnnouncementVariables extends StatefulWidget {
   AnnouncementVariables({Key key, @required this.announcements})
@@ -117,29 +117,25 @@ class Single_Announcement extends StatelessWidget {
                 );
               },
               child: GridTile(
-                footer: Container(
-                  color: Colors.white70,
-                  child: ListTile(
-                    title: Column(
-                      children: <Widget>[
-                        Text(
-                          announcement.name,
-                          style: TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                        )
-                      ],
+                  footer: Container(
+                    color: Colors.white70,
+                    child: ListTile(
+                      title: Column(
+                        children: <Widget>[
+                          Text(
+                            announcement.name,
+                            style: TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                          )
+                        ],
+                      ),
                     ),
                   ),
-                ),
-                child: CachedNetworkImage(
-                  placeholder: (context, url) => Expanded(
-                    child: Container(color: Colors.grey[300]),
-                  ),
-                  imageUrl: WebAPI.baseURL + announcement.poster.url,
-                ),
-              ),
+                  child: CachedImageBox(
+                    imageurl: WebAPI.baseURL + announcement.poster.url,
+                  )),
             ),
           ),
         ),

--- a/lib/EventWidget.dart
+++ b/lib/EventWidget.dart
@@ -5,13 +5,9 @@ import 'package:connect_plus/services/web_api.dart';
 import 'package:connect_plus/widgets/ImageRotate.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'Navbar.dart';
 import 'widgets/Utils.dart';
-import 'dart:convert';
-import 'widgets/Indicator.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:cached_network_image/cached_network_image.dart';
-
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class EventWidget extends StatefulWidget {
   EventWidget({Key key, @required this.event}) : super(key: key);
@@ -63,14 +59,11 @@ class _EventState extends State<EventWidget> with TickerProviderStateMixin {
 
   Widget urlToImage(String imageURL) {
     return Expanded(
-        child: FittedBox(fit: BoxFit.contain,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-            imageURL,
-          ),
-        )
-    );
+        child: FittedBox(
+            fit: BoxFit.contain,
+            child: CachedImageBox(
+              imageurl: imageURL,
+            )));
   }
 
   List<Widget> eventsByERG() {
@@ -124,10 +117,8 @@ class _EventState extends State<EventWidget> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-              WebAPI.baseURL + event.poster.url,
+          child: CachedImageBox(
+            imageurl: WebAPI.baseURL + event.poster.url,
           ),
         )
       ],

--- a/lib/Events.dart
+++ b/lib/Events.dart
@@ -12,7 +12,7 @@ import 'package:connect_plus/EventWidget.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:localstorage/localstorage.dart';
 import 'dart:math';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class Events extends StatefulWidget {
   Events({
@@ -143,11 +143,7 @@ class MyEventsPageState extends State<Events>
       final imageURL = WebAPI.baseURL + featuredEvent.poster.url;
       return FittedBox(
         fit: BoxFit.fill,
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl:
-          imageURL,
-        ),
+        child: CachedImageBox(imageurl: imageURL),
       );
     } catch (Exception) {
       return Scaffold(
@@ -161,14 +157,10 @@ class MyEventsPageState extends State<Events>
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.width *
             0.50, // otherwise the logo will be tiny
-        child: FittedBox(fit: BoxFit.fill,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-            imageUrl,
-          ),
-        )
-    );
+        child: FittedBox(
+          fit: BoxFit.fill,
+          child: CachedImageBox(imageurl: imageUrl),
+        ));
   }
 
   Widget search() {
@@ -234,14 +226,14 @@ class MyEventsPageState extends State<Events>
         selectedTextBackgroundColor: Utils.header,
         searchFieldHintText: "Search Here",
         selectedTextList: selectedCountList, onApplyButtonClick: (list) {
-          if (list != null) {
-            setState(() {
-              selectedCountList = List.from(list);
-              filterData();
-            });
-          }
-          Navigator.pop(context);
+      if (list != null) {
+        setState(() {
+          selectedCountList = List.from(list);
+          filterData();
         });
+      }
+      Navigator.pop(context);
+    });
   }
 
   @override
@@ -321,70 +313,70 @@ class MyEventsPageState extends State<Events>
                     child: Container(
                         child: SingleChildScrollView(
                             child: Column(children: <Widget>[
-                              SizedBox(
-                                height: 10,
-                              ),
-                              ListView(
-                                shrinkWrap: true,
-                                physics: ScrollPhysics(),
-                                children: mapIndexed(_filteredData, (index, event) {
-                                  return Center(
-                                      child: SizedBox(
-                                        width: width * 0.8,
-                                        child: Column(
-                                          crossAxisAlignment: CrossAxisAlignment.center,
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: <Widget>[
-                                            Text(
-                                              event.name.toString(),
-                                              textAlign: TextAlign.center,
-                                              style: TextStyle(
-                                                  fontSize: 23,
-                                                  color: Colors.black87,
-                                                  fontWeight: FontWeight.w500),
+                      SizedBox(
+                        height: 10,
+                      ),
+                      ListView(
+                        shrinkWrap: true,
+                        physics: ScrollPhysics(),
+                        children: mapIndexed(_filteredData, (index, event) {
+                          return Center(
+                              child: SizedBox(
+                            width: width * 0.8,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                Text(
+                                  event.name.toString(),
+                                  textAlign: TextAlign.center,
+                                  style: TextStyle(
+                                      fontSize: 23,
+                                      color: Colors.black87,
+                                      fontWeight: FontWeight.w500),
+                                ),
+                                SizedBox(
+                                  height: 5,
+                                ),
+                                Card(
+                                    elevation: 7.0,
+                                    clipBehavior: Clip.antiAlias,
+                                    margin: EdgeInsets.all(12.0),
+                                    shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.all(
+                                            Radius.circular(10.0))),
+                                    child: InkWell(
+                                      child: urlToImage(
+                                          WebAPI.baseURL + event.poster.url),
+                                      onTap: () {
+                                        if (event.runtimeType == Event) {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (context) =>
+                                                  EventWidget(event: event),
                                             ),
-                                            SizedBox(
-                                              height: 5,
+                                          );
+                                        } else {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (context) =>
+                                                  WebinarWidget(webinar: event),
                                             ),
-                                            Card(
-                                                elevation: 7.0,
-                                                clipBehavior: Clip.antiAlias,
-                                                margin: EdgeInsets.all(12.0),
-                                                shape: RoundedRectangleBorder(
-                                                    borderRadius: BorderRadius.all(
-                                                        Radius.circular(10.0))),
-                                                child: InkWell(
-                                                  child: urlToImage(
-                                                      WebAPI.baseURL + event.poster.url),
-                                                  onTap: () {
-                                                    if (event.runtimeType == Event) {
-                                                      Navigator.push(
-                                                        context,
-                                                        MaterialPageRoute(
-                                                          builder: (context) =>
-                                                              EventWidget(event: event),
-                                                        ),
-                                                      );
-                                                    } else {
-                                                      Navigator.push(
-                                                        context,
-                                                        MaterialPageRoute(
-                                                          builder: (context) =>
-                                                              WebinarWidget(webinar: event),
-                                                        ),
-                                                      );
-                                                    }
-                                                  },
-                                                )),
-                                            SizedBox(
-                                              height: 30,
-                                            )
-                                          ],
-                                        ),
-                                      ));
-                                }).toList(),
-                              ),
-                            ]))))));
+                                          );
+                                        }
+                                      },
+                                    )),
+                                SizedBox(
+                                  height: 30,
+                                )
+                              ],
+                            ),
+                          ));
+                        }).toList(),
+                      ),
+                    ]))))));
     } catch (err) {
       return Scaffold(
         body: ImageRotate(),
@@ -397,7 +389,7 @@ class MyEventsPageState extends State<Events>
     final filter = searchAll
         .where(
           (entry) => entry.name.toLowerCase().startsWith(pattern.toLowerCase()),
-    )
+        )
         .toList();
     return filter;
   }

--- a/lib/EventsVariable.dart
+++ b/lib/EventsVariable.dart
@@ -10,7 +10,7 @@ import 'package:intl/intl.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:connect_plus/EventWidget.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class EventsVariables extends StatefulWidget {
   EventsVariables({Key key, @required this.events, @required this.webinars})
@@ -213,12 +213,8 @@ class Single_Event extends StatelessWidget {
                       ]),
                     ),
                   ),
-                  child: CachedNetworkImage(
-                    placeholder: (context, url) => Expanded(
-                      child: Container(color: Colors.grey[300]),
-                    ),
-                    imageUrl: WebAPI.baseURL + event.poster.url,
-                  ),
+                  child: CachedImageBox(
+                      imageurl: WebAPI.baseURL + event.poster.url),
                 ),
               ),
             ),

--- a/lib/OfferVariables.dart
+++ b/lib/OfferVariables.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class OfferVariables extends StatefulWidget {
   OfferVariables({Key key, @required this.offers}) : super(key: key);
@@ -152,11 +152,8 @@ class Single_Offer extends StatelessWidget {
                     ),
                   ),
                 ),
-                child: CachedNetworkImage(
-                  placeholder: (context, url) => Expanded(
-                    child: Container(color: Colors.grey[300]),
-                  ),
-                  imageUrl: WebAPI.baseURL + offer.logo.url,
+                child: CachedImageBox(
+                  imageurl: WebAPI.baseURL + offer.logo.url,
                 ),
               ),
             ),

--- a/lib/OfferWidget.dart
+++ b/lib/OfferWidget.dart
@@ -8,10 +8,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:localstorage/localstorage.dart';
-import 'Navbar.dart';
 import 'widgets/Utils.dart';
-import 'widgets/Indicator.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
+
 class OfferWidget extends StatefulWidget {
   OfferWidget({
     Key key,
@@ -75,10 +74,8 @@ class _OfferState extends State<OfferWidget> with TickerProviderStateMixin {
         width: MediaQuery.of(context)
             .size
             .width, // otherwise the logo will be tiny
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl:
-            imageURL,
+        child: CachedImageBox(
+          imageurl: imageURL,
         ),
       ),
     );
@@ -154,10 +151,8 @@ class _OfferState extends State<OfferWidget> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-            WebAPI.baseURL + widget.offer.logo.url,
+          child: CachedImageBox(
+            imageurl: WebAPI.baseURL + widget.offer.logo.url,
           ),
         )
       ],

--- a/lib/Offers.dart
+++ b/lib/Offers.dart
@@ -9,7 +9,8 @@ import 'package:localstorage/localstorage.dart';
 import 'package:connect_plus/OfferWidget.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:connect_plus/utils/map_indexed.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
+
 class Offers extends StatefulWidget {
   Offers({Key key, this.offerCategory}) : super(key: key);
 
@@ -88,10 +89,8 @@ class _OffersState extends State<Offers> {
       setState(() {
         recent.forEach((element) {
           element.highlight.forEach((h) {
-            recentOffers.add(CachedNetworkImage(
-              placeholder: (context, url) => CircularProgressIndicator(),
-              imageUrl:
-              WebAPI.baseURL + h.url,
+            recentOffers.add(CachedImageBox(
+              imageurl: WebAPI.baseURL + h.url,
             ));
           });
         });
@@ -128,13 +127,11 @@ class _OffersState extends State<Offers> {
     return Expanded(
       child: SizedBox(
         width: 250, // otherwise the logo will be tiny
-        child: FittedBox(fit: BoxFit.contain,
-            child: CachedNetworkImage(
-              placeholder: (context, url) => CircularProgressIndicator(),
-              imageUrl:
-                imageURL,
-          )
-        ),
+        child: FittedBox(
+            fit: BoxFit.contain,
+            child: CachedImageBox(
+              imageurl: imageURL,
+            )),
       ),
     );
   }
@@ -144,10 +141,8 @@ class _OffersState extends State<Offers> {
       final url = WebAPI.baseURL + offers[randIndexOffer].logo.url;
       return FittedBox(
         fit: BoxFit.contain,
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl:
-            url,
+        child: CachedImageBox(
+          imageurl: url,
         ),
       );
     } catch (Exception) {

--- a/lib/WebinarWidget.dart
+++ b/lib/WebinarWidget.dart
@@ -6,12 +6,10 @@ import 'package:connect_plus/services/web_api.dart';
 import 'package:connect_plus/widgets/ImageRotate.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'Navbar.dart';
 import 'widgets/Utils.dart';
-import 'dart:convert';
-import 'widgets/Indicator.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
+
 class WebinarWidget extends StatefulWidget {
   WebinarWidget({Key key, @required this.webinar}) : super(key: key);
 
@@ -55,10 +53,8 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
     return Expanded(
       child: SizedBox(
         width: 250, // otherwise the logo will be tiny
-        child: CachedNetworkImage(
-          placeholder: (context, url) => CircularProgressIndicator(),
-          imageUrl:
-          imageURL,
+        child: CachedImageBox(
+          imageurl: imageURL,
         ),
       ),
     );
@@ -96,7 +92,7 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
                       ergwebinar.name,
                       textAlign: TextAlign.center,
                       style:
-                      TextStyle(fontSize: size * 35, color: Utils.header),
+                          TextStyle(fontSize: size * 35, color: Utils.header),
                     ),
                   )
                 ],
@@ -134,13 +130,13 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
   }
 
   Widget _icon(
-      IconData icon, {
-        Color color = Utils.iconColor,
-        double size = 20,
-        double padding = 10,
-        bool isOutLine = false,
-        Function onPressed,
-      }) {
+    IconData icon, {
+    Color color = Utils.iconColor,
+    double size = 20,
+    double padding = 10,
+    bool isOutLine = false,
+    Function onPressed,
+  }) {
     return Container(
       height: 40,
       width: 40,
@@ -167,10 +163,8 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           width: MediaQuery.of(context).size.width,
-          child: CachedNetworkImage(
-            placeholder: (context, url) => CircularProgressIndicator(),
-            imageUrl:
-            WebAPI.baseURL + webinar.poster.url,
+          child: CachedImageBox(
+            imageurl: WebAPI.baseURL + webinar.poster.url,
           ),
         )
       ],

--- a/lib/announcement_widget.dart
+++ b/lib/announcement_widget.dart
@@ -2,7 +2,7 @@ import 'package:connect_plus/services/web_api.dart';
 import 'package:connect_plus/widgets/Utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 import 'package:connect_plus/models/announcement.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:intl/intl.dart';
@@ -60,17 +60,10 @@ class AnnouncementImage extends StatelessWidget {
   }) : super(key: key);
 
   final Announcement announcement;
-
   @override
   Widget build(BuildContext context) {
-    return CachedNetworkImage(
-      height: MediaQuery.of(context).size.height * 0.3,
-      imageUrl: WebAPI.baseURL + announcement.poster.url,
-      placeholder: (_, __) => SizedBox(
-        height: 40,
-        width: 40,
-        child: CircularProgressIndicator(),
-      ),
+    return CachedImageBox(
+      imageurl: WebAPI.baseURL + announcement.poster.url,
     );
   }
 }

--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
-
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 import 'package:connect_plus/models/announcement.dart';
 import 'package:connect_plus/services/web_api.dart';
 import 'package:connect_plus/widgets/Utils.dart';
@@ -176,14 +175,11 @@ class AnnouncementImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: MediaQuery.of(context).size.width,
-      height: MediaQuery.of(context).size.width * 0.5,
-      child: CachedNetworkImage(
-        fit: BoxFit.fill,
-        placeholder: (context, url) => LoadingIndicator(),
-        imageUrl: WebAPI.baseURL + announcement.poster.url,
-      ),
-    );
+        width: MediaQuery.of(context).size.width,
+        height: MediaQuery.of(context).size.width * 0.5,
+        child: CachedImageBox(
+          imageurl: WebAPI.baseURL + announcement.poster.url,
+        ));
   }
 }
 

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -17,6 +17,7 @@ import 'EventsVariable.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:connect_plus/models/announcement.dart';
 import 'AnnouncementVariables.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
 
 class MyHomePage extends StatefulWidget {
   MyHomePage({Key key, this.title}) : super(key: key);
@@ -29,7 +30,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   TextStyle style = TextStyle(fontFamily: 'Roboto', fontSize: 16.0);
 
-  List<CachedNetworkImage> sliderPosters = [];
+  List<CachedImageBox> sliderPosters = [];
   List<Event> events = [];
   List<Offer> offers = [];
   List<Webinar> webinars = [];
@@ -97,12 +98,7 @@ class _MyHomePageState extends State<MyHomePage> {
       setState(() {
         recent.forEach((element) {
           element.highlight.forEach((h) {
-            sliderPosters.add(CachedNetworkImage(
-              placeholder: (context, url) => Expanded(
-                child: Container(color: Colors.grey[300]),
-              ),
-              imageUrl: WebAPI.baseURL + h.url,
-            ));
+            sliderPosters.add(CachedImageBox(imageurl: WebAPI.baseURL + h.url));
           });
         });
         highlightsLoaded = true;
@@ -112,7 +108,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   // TODO: Move business logic outside of UI
   Future<void> getErgSliderPosters() async {
-    List<CachedNetworkImage> posters = [];
+    List<CachedImageBox> posters = [];
     final int ergPosterLimit = 1;
 
     List<Event> events = await WebAPI.getSliderEvents();
@@ -159,12 +155,7 @@ class _MyHomePageState extends State<MyHomePage> {
       for (int i = 0; i < ergPosterLimit; i++) {
         // will break when poster field changes
         posters.add(
-          CachedNetworkImage(
-            placeholder: (context, url) => Expanded(
-              child: Container(color: Colors.grey[300]),
-            ),
-            imageUrl: WebAPI.baseURL + items[i].poster.ur,
-          ),
+          CachedImageBox(imageurl: WebAPI.baseURL + items[i].poster.ur),
         );
       }
     });

--- a/lib/included.dart
+++ b/lib/included.dart
@@ -6,7 +6,8 @@ import 'package:connect_plus/widgets/Utils.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:connect_plus/Navbar.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:connect_plus/widgets/CachedImageBox.dart';
+
 class Included extends StatefulWidget {
   Included({Key key, this.title}) : super(key: key);
   final String title;
@@ -108,16 +109,14 @@ class _IncludedState extends State<Included> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: <Widget>[
                   Container(
-                      color: Colors.white,
-                      child: SizedBox(
-                        height: MediaQuery.of(context).size.height * 0.3,
-                        width: MediaQuery.of(context).size.width * 0.65,
-                        child: CachedNetworkImage(
-                          placeholder: (context, url) => CircularProgressIndicator(),
-                          imageUrl:
-                            WebAPI.baseURL + ergsList[index].poster.url,
-                        ),
+                    color: Colors.white,
+                    child: SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.3,
+                      width: MediaQuery.of(context).size.width * 0.65,
+                      child: CachedImageBox(
+                        imageurl: WebAPI.baseURL + ergsList[index].poster.url,
                       ),
+                    ),
                   ),
                   SizedBox(
                     height: 20,

--- a/lib/widgets/CachedImageBox.dart
+++ b/lib/widgets/CachedImageBox.dart
@@ -1,0 +1,17 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+class CachedImageBox extends StatelessWidget {
+  CachedImageBox({Key key, @required this.imageurl}) : super(key: key);
+  final String imageurl;
+  @override
+  Widget build(BuildContext context) {
+    return CachedNetworkImage(
+      placeholder: (context, url) => Expanded(
+        child: Container(color: Colors.grey[300]),
+      ),
+      imageUrl: imageurl,
+      fit: BoxFit.fill,
+    );
+  }
+}


### PR DESCRIPTION
## What?
Create new Image Box called `CachedImageBox`, take one attribute which is `imageurl`

## Why?
Across the app there was a lot of image views, in each instance in the app we needed to give it an Imageurl, decoration, size, progress indicator and its styling, so any modification would result in modification in many instances across the app.

## How?
replaced all image views across the app to the new `CachedImageBox` widget and send the imageurl parameter.

## Tasks
- [x] Creat new Image Box widget
- [x] Image Fill the box
- [x] replace all image instances with the new widget

## ScreenShots
<p>
<img src="https://user-images.githubusercontent.com/33899216/116541796-329f9700-a8ec-11eb-82e1-64645dc97620.png" width="360">
<img src="https://user-images.githubusercontent.com/33899216/116541828-3c28ff00-a8ec-11eb-8f55-91a726d2e910.png" width="360">
</p>


