### PR TITLE
Feature 177925106 add announcements and offers to carousel

### DIFF
--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -1,6 +1,8 @@
 import 'package:carousel_pro/carousel_pro.dart';
 import 'package:connect_plus/announcements.dart';
+import 'package:connect_plus/models/activity.dart';
 import 'package:connect_plus/models/event.dart';
+import 'package:connect_plus/models/occurrence.dart';
 import 'package:connect_plus/models/offer.dart';
 import 'package:connect_plus/models/webinar.dart';
 import 'package:connect_plus/services/web_api.dart';
@@ -47,11 +49,16 @@ class _MyHomePageState extends State<MyHomePage> {
     offers = [];
     webinars = [];
     super.initState();
-    getEvents();
-    getWebinars();
-    getOffers();
-    getRecentEventsPosters();
-    getAnnouncements();
+  }
+
+  Future<void> _loadData() async {
+    await getEvents();
+    await getWebinars();
+    await getOffers();
+    await getAnnouncements();
+    await getRecentEventsPosters();
+    await getSliderPosters();
+    return;
   }
 
   @override
@@ -62,20 +69,16 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> getEvents() async {
     final allEvents = await WebAPI.getEvents();
     if (this.mounted) {
-      setState(() {
-        events = allEvents;
-        eventsLoaded = true;
-      });
+      events = allEvents;
+      eventsLoaded = true;
     }
   }
 
   Future<void> getWebinars() async {
     final allWebinars = await WebAPI.getWebinars();
     if (this.mounted) {
-      setState(() {
-        webinars = allWebinars;
-        webinarsLoaded = true;
-      });
+      webinars = allWebinars;
+      webinarsLoaded = true;
     }
   }
 
@@ -83,10 +86,8 @@ class _MyHomePageState extends State<MyHomePage> {
     try {
       final recentOffers = await WebAPI.getRecentOffers();
       if (this.mounted) {
-        setState(() {
-          this.offers = recentOffers;
-          offersLoaded = true;
-        });
+        this.offers = recentOffers;
+        offersLoaded = true;
       }
     } catch (e) {}
   }
@@ -95,27 +96,27 @@ class _MyHomePageState extends State<MyHomePage> {
     this.sliderPosters.clear();
     var recent = await WebAPI.getEventHighlights();
     if (this.mounted) {
-      setState(() {
-        recent.forEach((element) {
-          element.highlight.forEach((h) {
-            sliderPosters.add(CachedImageBox(imageurl: WebAPI.baseURL + h.url));
-          });
+      recent.forEach((element) {
+        element.highlight.forEach((h) {
+          sliderPosters.add(CachedImageBox(imageurl: WebAPI.baseURL + h.url));
         });
-        highlightsLoaded = true;
       });
+      highlightsLoaded = true;
     }
   }
 
   // TODO: Move business logic outside of UI
+  /// Gets the posters related to ERGs that will be displayed in the
+  /// carousel slider.
+  ///
+  /// Must be called after events, offers, webinars, are loaded
   Future<void> getErgSliderPosters() async {
     List<CachedImageBox> posters = [];
     final int ergPosterLimit = 1;
 
-    List<Event> events = await WebAPI.getSliderEvents();
-    List<Webinar> webinars = await WebAPI.getSliderWebinars();
+    List<Activity> activities = await WebAPI.getActivities();
 
-    // TODO: create a superclass for webinars and events
-    Map<ERG, List<dynamic>> ergItems = {};
+    Map<ERG, List<Occurrence>> ergItems = {};
 
     // add events to erg owner
     events.forEach((event) {
@@ -141,57 +142,100 @@ class _MyHomePageState extends State<MyHomePage> {
       }
     });
 
+    offers.forEach((offer) {
+      if (offer.slider) {
+        ERG erg = offer.erg;
+        if (ergItems.containsKey(erg)) {
+          ergItems[erg].add(offer);
+        } else {
+          ergItems[erg] = [offer];
+        }
+      }
+    });
+    activities.forEach((activity) {
+      if (activity.slider) {
+        ERG erg = activity.erg;
+        if (ergItems.containsKey(erg)) {
+          ergItems[erg].add(activity);
+        } else {
+          ergItems[erg] = [activity];
+        }
+      }
+    });
+
     // Sorts items for each erg
-    // superclass for webinar and events will make for much safer and cleaner code
-    // The following will break if webinar/event class changes createdAt field name
     ergItems.forEach((erg, items) {
       items.sort(
-        (item1, item2) => item2.createdAt.compareTo(item1.createdAt),
+        (item1, item2) => item2.date.compareTo(item1.date),
       );
       ergItems[erg] = items;
     });
 
     ergItems.forEach((erg, items) {
       for (int i = 0; i < ergPosterLimit; i++) {
-        // will break when poster field changes
         posters.add(
-          CachedImageBox(imageurl: WebAPI.baseURL + items[i].poster.ur),
+          CachedImageBox(imageurl: WebAPI.baseURL + items[i].poster.url),
         );
       }
     });
-    setState(() {
-      sliderPosters.addAll(posters);
+    sliderPosters.addAll(posters);
+  }
+
+  void getSliderAnnouncements() {
+    num numberOfShownAnnouncements = 2;
+    List<Announcement> sortedAnnouncements = announcements;
+    sortedAnnouncements.sort((a1, a2) {
+      if (a1.deadline == null) return -1;
+      if (a2.deadline == null) return 1;
+      return a2.deadline.compareTo(a1.deadline);
     });
+
+    List<Announcement> unexpiredAnnouncements = sortedAnnouncements
+        .where(
+          (announcement) =>
+              announcement.slider == true &&
+              announcement.erg.name.toLowerCase() ==
+                  "internal comms" && //TODO store this somewhere else
+              (announcement.deadline == null ||
+                  announcement.deadline.isAfter(DateTime.now())),
+        )
+        .toList();
+    unexpiredAnnouncements =
+        unexpiredAnnouncements.take(numberOfShownAnnouncements).toList();
+
+    List<CachedImageBox> posters = unexpiredAnnouncements
+        .map(
+          (announcement) => CachedImageBox(
+            imageurl: WebAPI.baseURL + announcement.poster.url,
+          ),
+        )
+        .toList();
+
+    sliderPosters.addAll(posters);
   }
 
   Future<void> getSliderPosters() async {
     sliderPosters.clear();
     await getRecentEventsPosters();
     await getErgSliderPosters();
+    getSliderAnnouncements();
     sliderPostersLoaded = true;
   }
 
   Future<void> getAnnouncements() async {
     final allAnnouncements = await WebAPI.getAnnouncements();
     if (this.mounted) {
-      setState(() {
-        announcements = allAnnouncements;
-        announcementsLoaded = true;
-      });
+      announcements = allAnnouncements;
+      announcementsLoaded = true;
     }
   }
 
   Future<void> _refreshData() async {
-    setState(() {
-      // eventsLoaded = false;
-      // webinarsLoaded = false;
-      // offersLoaded = false;
-      // highlightsLoaded = false;
-      getEvents();
-      getWebinars();
-      getOffers();
-      getSliderPosters();
-    });
+    await getEvents();
+    await getWebinars();
+    await getOffers();
+    await getSliderPosters();
+    setState(() {});
   }
 
   Widget seeMore(String view) {
@@ -373,56 +417,50 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    if (highlightsLoaded &&
-        webinarsLoaded &&
-        eventsLoaded &&
-        offersLoaded &&
-        announcementsLoaded)
-      return RefreshIndicator(
-          onRefresh: _refreshData,
-          child: WillPopScope(
-            onWillPop: () async => false,
-            child: Scaffold(
-              appBar: AppBar(
-                // Here we take the value from the MyHomePage object that was created by
-                // the App.build method, and use it to set our appbar title.
-                title: Text("Home"),
-                centerTitle: true,
-                backgroundColor: Utils.header,
-                flexibleSpace: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      colors: [
-                        Utils.secondaryColor,
-                        Utils.primaryColor,
-                      ],
-                      begin: Alignment.topRight,
-                      end: Alignment.bottomLeft,
+    return FutureBuilder<void>(
+        future: _loadData(),
+        builder: (context, snapshot) {
+          if (!highlightsLoaded &&
+              !webinarsLoaded &&
+              !eventsLoaded &&
+              !offersLoaded &&
+              !announcementsLoaded) return Scaffold(body: ImageRotate());
+
+          return RefreshIndicator(
+              onRefresh: _refreshData,
+              child: WillPopScope(
+                onWillPop: () async => false,
+                child: Scaffold(
+                  appBar: AppBar(
+                    title: Text("Home"),
+                    centerTitle: true,
+                    backgroundColor: Utils.header,
+                    flexibleSpace: Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [
+                            Utils.secondaryColor,
+                            Utils.primaryColor,
+                          ],
+                          begin: Alignment.topRight,
+                          end: Alignment.bottomLeft,
+                        ),
+                      ),
                     ),
                   ),
-                ),
-              ),
-              drawer: NavDrawer(),
-              backgroundColor: Utils.background,
-              body: Stack(children: <Widget>[
-                Container(
-                  child: SingleChildScrollView(
-                    child: Column(
-                      children: getContent(),
+                  drawer: NavDrawer(),
+                  backgroundColor: Utils.background,
+                  body: Stack(children: <Widget>[
+                    Container(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          children: getContent(),
+                        ),
+                      ),
                     ),
-                  ),
+                  ]),
                 ),
-              ]),
-            ),
-          ));
-    else {
-      return Scaffold(body: ImageRotate());
-    }
+              ));
+        });
   }
 }

--- a/lib/homepage.dart
+++ b/lib/homepage.dart
@@ -122,7 +122,7 @@ class _MyHomePageState extends State<MyHomePage> {
     events.forEach((event) {
       if (event.slider) {
         ERG erg = event.erg;
-        if (ergItems.containsKey(erg)) {
+        if (erg != null && ergItems.containsKey(erg)) {
           ergItems[erg].add(event);
         } else {
           ergItems[erg] = [event];
@@ -134,7 +134,7 @@ class _MyHomePageState extends State<MyHomePage> {
     webinars.forEach((webinar) {
       if (webinar.slider) {
         ERG erg = webinar.erg;
-        if (ergItems.containsKey(erg)) {
+        if (erg != null && ergItems.containsKey(erg)) {
           ergItems[erg].add(webinar);
         } else {
           ergItems[erg] = [webinar];
@@ -145,7 +145,7 @@ class _MyHomePageState extends State<MyHomePage> {
     offers.forEach((offer) {
       if (offer.slider) {
         ERG erg = offer.erg;
-        if (ergItems.containsKey(erg)) {
+        if (erg != null && ergItems.containsKey(erg)) {
           ergItems[erg].add(offer);
         } else {
           ergItems[erg] = [offer];
@@ -155,7 +155,7 @@ class _MyHomePageState extends State<MyHomePage> {
     activities.forEach((activity) {
       if (activity.slider) {
         ERG erg = activity.erg;
-        if (ergItems.containsKey(erg)) {
+        if (erg != null && ergItems.containsKey(erg)) {
           ergItems[erg].add(activity);
         } else {
           ergItems[erg] = [activity];

--- a/lib/models/activity.dart
+++ b/lib/models/activity.dart
@@ -2,126 +2,173 @@ import 'package:connect_plus/models/activityDate.dart';
 import 'package:connect_plus/models/admin_user.dart';
 import 'package:connect_plus/models/erg.dart';
 import 'package:connect_plus/models/image_file.dart';
+import 'package:connect_plus/models/occurrence.dart';
+import 'package:flutter/foundation.dart';
 
-class Activity {
-  String recurrence;
-  ImageFile poster;
-  String sId;
-  String name;
-  DateTime startDate;
-  DateTime endDate;
-  String onBehalfOf;
-  String venue;
-  String zoomID;
-  String days;
-  DateTime createdAt;
-  DateTime updatedAt;
-  int iV;
-  AdminUser createdBy;
-  AdminUser updatedBy;
-  String id;
-  List<DateTime> recurrenceDates;
-  ERG erg;
-  List<ActivityDate> activityDates;
+class Activity extends Occurrence {
+  final String _recurrence;
+  final ImageFile _poster;
+  final String _sId;
+  final String _name;
+  final DateTime _startDate;
+  final DateTime _endDate;
+  final String _onBehalfOf;
+  final String _venue;
+  final String _zoomID;
+  final String _days;
+  final DateTime _createdAt;
+  final DateTime _updatedAt;
+  final int _iV;
+  final AdminUser _createdBy;
+  final AdminUser _updatedBy;
+  final String _id;
+  List<DateTime> recurrenceDates; // public as web_api breaks otherwise
+  final ERG _erg;
+  final List<ActivityDate> _activityDates;
+  final bool _slider;
+
+  @override
+  String get name => _name;
+  @override
+  ImageFile get poster => _poster;
+  @override
+  DateTime get date => _createdAt;
+  @override
+  bool get slider => _slider;
+  String get recurrence => _recurrence;
+  String get sId => _sId;
+  DateTime get startDate => _startDate;
+  DateTime get endDate => _endDate;
+  String get onBehalfOf => _onBehalfOf;
+  String get venue => _venue;
+  String get zoomID => _zoomID;
+  String get days => _days;
+  DateTime get createdAt => _createdAt;
+  DateTime get updatedAt => _updatedAt;
+  int get iV => _iV;
+  AdminUser get createdBy => _createdBy;
+  AdminUser get updatedBy => _updatedBy;
+  String get id => _id;
+  ERG get erg => _erg;
+  List<ActivityDate> get activityDates => _activityDates;
 
   Activity({
-    this.recurrence,
-    this.poster,
-    this.sId,
-    this.name,
-    this.onBehalfOf,
-    this.startDate,
-    this.endDate,
-    this.zoomID,
-    this.venue,
-    this.days,
-    this.createdAt,
-    this.updatedAt,
-    this.iV,
-    this.recurrenceDates,
-    this.createdBy,
-    this.updatedBy,
-    this.id,
-    this.erg,
-    this.activityDates,
-  });
+    @required String recurrence,
+    @required ImageFile poster,
+    @required String sId,
+    @required String name,
+    @required String onBehalfOf,
+    @required DateTime startDate,
+    @required DateTime endDate,
+    @required String zoomID,
+    @required String venue,
+    @required String days,
+    @required DateTime createdAt,
+    @required DateTime updatedAt,
+    @required int iV,
+    @required this.recurrenceDates,
+    @required AdminUser createdBy,
+    @required AdminUser updatedBy,
+    @required String id,
+    @required ERG erg,
+    @required List<ActivityDate> activityDates,
+    @required bool slider,
+  })  : _recurrence = recurrence,
+        _poster = poster,
+        _sId = sId,
+        _name = name,
+        _onBehalfOf = onBehalfOf,
+        _startDate = startDate,
+        _endDate = endDate,
+        _zoomID = zoomID,
+        _venue = venue,
+        _days = days,
+        _createdAt = createdAt,
+        _updatedAt = updatedAt,
+        _iV = iV,
+        _createdBy = createdBy,
+        _updatedBy = updatedBy,
+        _id = id,
+        _erg = erg,
+        _activityDates = activityDates,
+        _slider = slider;
 
-  Activity.fromJson(Map<String, dynamic> json) {
-    recurrence = json['recurrence'];
-    if (json['poster'] != null) {
-      poster = new ImageFile.fromJson(json['poster']);
-    }
-    sId = json['_id'];
-    name = json['name'];
-    onBehalfOf = json['onBehalfOf'];
-
-    zoomID = json['zoomID'];
-    days = json['days'];
-
-    recurrenceDates = json['recurrenceDates'] != null
-        ? json['recurrenceDates'].cast<DateTime>()
-        : null;
-
-    endDate =
-        json['endDate'] != null ? DateTime.parse((json['endDate'])).toLocal() : null;
-    startDate =
-        json['startDate'] != null ? DateTime.parse((json['startDate'])).toLocal() : null;
-    createdAt =
-        json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
-    updatedAt =
-        json['updatedAt'] != null ? DateTime.parse((json['updatedAt'])) : null;
-    venue = json['venue'];
-    iV = json['__v'];
-    createdBy = json['created_by'] != null
-        ? new AdminUser.fromJson(json['created_by'])
-        : null;
-    updatedBy = json['updated_by'] != null
-        ? new AdminUser.fromJson(json['updated_by'])
-        : null;
-    erg = json['erg'] != null ? new ERG.fromJson(json['erg']) : null;
-    if (json['activity_dates'] != null) {
-      activityDates = new List<ActivityDate>();
-      json['activity_dates'].forEach((v) {
-        activityDates.add(new ActivityDate.fromJson(v));
-      });
-    }
-    id = json['id'];
+  factory Activity.fromJson(Map<String, dynamic> json) {
+    return Activity(
+      recurrence: json['recurrence'],
+      poster:
+          json['poster'] != null ? ImageFile.fromJson(json['poster']) : null,
+      sId: json['_id'],
+      name: json['name'],
+      onBehalfOf: json['onBehalfOf'],
+      zoomID: json['zoomID'],
+      days: json['days'],
+      recurrenceDates: json['recurrenceDates'] != null
+          ? json['recurrenceDates'].cast<DateTime>()
+          : null,
+      endDate: json['endDate'] != null
+          ? DateTime.parse((json['endDate'])).toLocal()
+          : null,
+      startDate: json['startDate'] != null
+          ? DateTime.parse((json['startDate'])).toLocal()
+          : null,
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse((json['createdAt']))
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse((json['updatedAt']))
+          : null,
+      venue: json['venue'],
+      iV: json['__v'],
+      createdBy: json['created_by'] != null
+          ? new AdminUser.fromJson(json['created_by'])
+          : null,
+      updatedBy: json['updated_by'] != null
+          ? new AdminUser.fromJson(json['updated_by'])
+          : null,
+      erg: json['erg'] != null ? new ERG.fromJson(json['erg']) : null,
+      activityDates: List<Map<String, dynamic>>.from(json['activity_dates'])
+          .map((activityDateJson) => ActivityDate.fromJson(activityDateJson))
+          .toList(),
+      id: json['id'],
+      slider: json['slider'] ?? false,
+    );
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
-    data['recurrence'] = this.recurrence;
-    if (this.poster != null) {
-      data['poster'] = this.poster.toJson();
+    data['recurrence'] = this._recurrence;
+    if (this._poster != null) {
+      data['poster'] = this._poster.toJson();
     }
-    data['onBehalfOf'] = this.onBehalfOf;
-    data['_id'] = this.sId;
-    data['name'] = this.name;
-    data['startDate'] = this.startDate;
-    data['endDate'] = this.endDate;
-    data['venue'] = this.venue;
-    data['zoomID'] = this.zoomID;
-    data['days'] = this.days;
-    data['createdAt'] = this.createdAt;
-    data['updatedAt'] = this.updatedAt;
+    data['onBehalfOf'] = this._onBehalfOf;
+    data['_id'] = this._sId;
+    data['name'] = this._name;
+    data['startDate'] = this._startDate;
+    data['endDate'] = this._endDate;
+    data['venue'] = this._venue;
+    data['zoomID'] = this._zoomID;
+    data['days'] = this._days;
+    data['createdAt'] = this._createdAt;
+    data['updatedAt'] = this._updatedAt;
     if (this.recurrenceDates != null) {
       data['recurrenceDates'] = this.recurrenceDates;
     }
-    data['__v'] = this.iV;
-    if (this.createdBy != null) {
-      data['created_by'] = this.createdBy.toJson();
+    data['__v'] = this._iV;
+    if (this._createdBy != null) {
+      data['created_by'] = this._createdBy.toJson();
     }
-    if (this.updatedBy != null) {
-      data['updated_by'] = this.updatedBy.toJson();
+    if (this._updatedBy != null) {
+      data['updated_by'] = this._updatedBy.toJson();
     }
-    if (this.erg != null) {
-      data['erg'] = this.erg.toJson();
+    if (this._erg != null) {
+      data['erg'] = this._erg.toJson();
     }
-    if (this.activityDates != null) {
+    if (this._activityDates != null) {
       data['activity_dates'] =
-          this.activityDates.map((v) => v.toJson()).toList();
+          this._activityDates.map((v) => v.toJson()).toList();
     }
-    data['id'] = this.id;
+    data['id'] = this._id;
     return data;
   }
 }

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -1,89 +1,131 @@
 import 'package:connect_plus/models/admin_user.dart';
 import 'package:connect_plus/models/erg.dart';
 import 'package:connect_plus/models/image_file.dart';
+import 'package:connect_plus/models/occurrence.dart';
+import 'package:flutter/foundation.dart';
 
-class Announcement {
-  String sId;
-  String name;
-  String description;
-  DateTime deadline;
-  DateTime createdAt;
-  DateTime updatedAt;
-  String onBehalfOf;
-  AdminUser createdBy;
-  ImageFile poster;
-  AdminUser updatedBy;
-  String id;
-  String trivia;
-  bool slider;
-  String link;
+class Announcement extends Occurrence {
+  final String _sId;
+  final String _name;
+  final String _description;
+  final DateTime _deadline;
+  final DateTime _createdAt;
+  final DateTime _updatedAt;
+  final String _onBehalfOf;
+  final AdminUser _createdBy;
+  final ImageFile _poster;
+  final AdminUser _updatedBy;
+  final String _id;
+  final String _trivia;
+  final bool _slider;
+  final String _link;
+
+  @override
+  String get sId => _sId;
+  @override
+  String get name => _name;
+  @override
+  ImageFile get poster => _poster;
+  @override
+  bool get slider => _slider;
+  @override
+  DateTime get date => _createdAt;
+  String get description => _description;
+  DateTime get deadline => _deadline;
+  DateTime get createdAt => _createdAt;
+  DateTime get updatedAt => _updatedAt;
+  String get onBehalfOf => _onBehalfOf;
+  AdminUser get createdBy => _createdBy;
+
+  AdminUser get updatedBy => _updatedBy;
+  String get id => _id;
+  String get trivia => _trivia;
+  String get link => _link;
 
   Announcement({
-    this.sId,
-    this.name,
-    this.createdAt,
-    this.description,
-    this.deadline,
-    this.onBehalfOf,
-    this.updatedAt,
-    this.createdBy,
-    this.poster,
-    this.updatedBy,
-    this.id,
-    this.slider,
-    this.trivia,
-    this.link,
-  });
+    @required String sId,
+    @required String name,
+    @required DateTime createdAt,
+    @required String description,
+    @required DateTime deadline,
+    @required String onBehalfOf,
+    @required DateTime updatedAt,
+    @required AdminUser createdBy,
+    @required ImageFile poster,
+    @required AdminUser updatedBy,
+    @required String id,
+    @required bool slider,
+    @required String trivia,
+    @required String link,
+  })  : _sId = sId,
+        _name = name,
+        _createdAt = createdAt,
+        _description = description,
+        _deadline = deadline,
+        _onBehalfOf = onBehalfOf,
+        _updatedAt = updatedAt,
+        _createdBy = createdBy,
+        _poster = poster,
+        _updatedBy = updatedBy,
+        _id = id,
+        _slider = slider,
+        _trivia = trivia,
+        _link = link;
 
-  Announcement.fromJson(Map<String, dynamic> json) {
-    sId = json['_id'];
-    name = json['name'];
-    onBehalfOf = json['onBehalfOf'];
-    description = json['description'];
-    createdAt =
-        json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
-    deadline = json['deadline'] != null
-        ? DateTime.parse((json['deadline'])).toLocal()
-        : null;
-    updatedAt =
-        json['updatedAt'] != null ? DateTime.parse((json['updatedAt'])) : null;
-    createdBy = json['created_by'] != null
-        ? new AdminUser.fromJson(json['created_by'])
-        : null;
-    poster =
-        json['poster'] != null ? new ImageFile.fromJson(json['poster']) : null;
-    updatedBy = json['updated_by'] != null
-        ? new AdminUser.fromJson(json['updated_by'])
-        : null;
-    id = json['id'];
-    slider = json['slider'] ?? false;
-    trivia =
-        json['trivia'] == "" ? null : json['trivia']; // will auto set to null
-    link = json['link'] == "" ? null : json['link']; // will auto set to null
+  factory Announcement.fromJson(Map<String, dynamic> json) {
+    return Announcement(
+      sId: json['_id'],
+      name: json['name'],
+      onBehalfOf: json['onBehalfOf'],
+      description: json['description'],
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse((json['createdAt']))
+          : null,
+      deadline: json['deadline'] != null
+          ? DateTime.parse((json['deadline'])).toLocal()
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse((json['updatedAt']))
+          : null,
+      createdBy: json['created_by'] != null
+          ? new AdminUser.fromJson(json['created_by'])
+          : null,
+      poster: json['poster'] != null
+          ? new ImageFile.fromJson(json['poster'])
+          : null,
+      updatedBy: json['updated_by'] != null
+          ? new AdminUser.fromJson(json['updated_by'])
+          : null,
+      id: json['id'],
+      slider: json['slider'] ?? false,
+      trivia:
+          json['trivia'] == "" ? null : json['trivia'], // will auto set to null
+      link: json['link'] == "" ? null : json['link'], // will auto set to null
+    );
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
-    data['_id'] = this.sId;
-    data['name'] = this.name;
-    data['onBehalfOf'] = this.onBehalfOf;
-    data['deadline'] = this.deadline;
-    data['createdAt'] = this.createdAt;
-    data['updatedAt'] = this.updatedAt;
-    data['description'] = this.description;
-    data['slider'] = this.slider;
-    if (this.createdBy != null) {
-      data['created_by'] = this.createdBy.toJson();
+    data['_id'] = this._sId;
+    data['name'] = this._name;
+    data['onBehalfOf'] = this._onBehalfOf;
+    data['deadline'] = this._deadline;
+    data['createdAt'] = this._createdAt;
+    data['updatedAt'] = this._updatedAt;
+    data['description'] = this._description;
+    data['slider'] = this._slider;
+    if (this._createdBy != null) {
+      data['created_by'] = this._createdBy.toJson();
     }
-    if (this.poster != null) {
-      data['poster'] = this.poster.toJson();
+    if (this._poster != null) {
+      data['poster'] = this._poster.toJson();
     }
-    if (this.updatedBy != null) {
-      data['updated_by'] = this.updatedBy.toJson();
+    if (this._updatedBy != null) {
+      data['updated_by'] = this._updatedBy.toJson();
     }
-    data['trivia'] = this.trivia;
-    data['id'] = this.id;
-    data['link'] = this.link;
+    data['trivia'] = this._trivia;
+    data['id'] = this._id;
+    data['link'] = this._link;
     return data;
   }
 }

--- a/lib/models/announcement.dart
+++ b/lib/models/announcement.dart
@@ -19,6 +19,7 @@ class Announcement extends Occurrence {
   final String _trivia;
   final bool _slider;
   final String _link;
+  final ERG _erg;
 
   @override
   String get sId => _sId;
@@ -30,6 +31,8 @@ class Announcement extends Occurrence {
   bool get slider => _slider;
   @override
   DateTime get date => _createdAt;
+  @override
+  ERG get erg => _erg;
   String get description => _description;
   DateTime get deadline => _deadline;
   DateTime get createdAt => _createdAt;
@@ -57,6 +60,7 @@ class Announcement extends Occurrence {
     @required bool slider,
     @required String trivia,
     @required String link,
+    @required ERG erg,
   })  : _sId = sId,
         _name = name,
         _createdAt = createdAt,
@@ -70,7 +74,8 @@ class Announcement extends Occurrence {
         _id = id,
         _slider = slider,
         _trivia = trivia,
-        _link = link;
+        _link = link,
+        _erg = erg;
 
   factory Announcement.fromJson(Map<String, dynamic> json) {
     return Announcement(
@@ -101,6 +106,7 @@ class Announcement extends Occurrence {
       trivia:
           json['trivia'] == "" ? null : json['trivia'], // will auto set to null
       link: json['link'] == "" ? null : json['link'], // will auto set to null
+      erg: json['erg'] != null ? ERG.fromJson(json['erg']) : null,
     );
   }
 
@@ -123,9 +129,13 @@ class Announcement extends Occurrence {
     if (this._updatedBy != null) {
       data['updated_by'] = this._updatedBy.toJson();
     }
+    if (this._erg != null) {
+      data['erg'] = this._erg.toJson();
+    }
     data['trivia'] = this._trivia;
     data['id'] = this._id;
     data['link'] = this._link;
+
     return data;
   }
 }

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -2,106 +2,155 @@ import 'package:connect_plus/models/admin_user.dart';
 import 'package:connect_plus/models/image_file.dart';
 
 import 'package:connect_plus/models/erg.dart';
+import 'package:connect_plus/models/occurrence.dart';
+import 'package:flutter/foundation.dart';
 
-class Event {
-  String status;
-  String sId;
-  String name;
-  String venue;
-  DateTime startDate;
-  DateTime endDate;
-  DateTime createdAt;
-  DateTime updatedAt;
-  int iV;
-  String onBehalfOf;
-  AdminUser createdBy;
-  ImageFile poster;
-  AdminUser updatedBy;
-  ERG erg;
-  String id;
-  String trivia;
-  bool slider;
+class Event extends Occurrence {
+  final String _status;
+  final String _sId;
+  final String _name;
+  final String _venue;
+  final DateTime _startDate;
+  final DateTime _endDate;
+  final DateTime _createdAt;
+  final DateTime _updatedAt;
+  final int _iV;
+  final String _onBehalfOf;
+  final AdminUser _createdBy;
+  final ImageFile _poster;
+  final AdminUser _updatedBy;
+  final ERG _erg;
+  final String _id;
+  final String _trivia;
+  final bool _slider;
+  @override
+  DateTime get date => this._createdAt;
+
+  @override
+  String get name => this._name;
+
+  @override
+  ImageFile get poster => this._poster;
+
+  @override
+  String get sId => this._sId;
+
+  @override
+  bool get slider => this._slider;
+
+  String get status => this._status;
+  String get venue => this._venue;
+  DateTime get startDate => this._startDate;
+  DateTime get endDate => this._endDate;
+  DateTime get createdAt => this._createdAt;
+  DateTime get updatedAt => this._updatedAt;
+  AdminUser get updatedBy => this._updatedBy;
+  String get onBehalfOf => this._onBehalfOf;
+  int get iV => this._iV;
+  String get trivia => this._trivia;
+  String get id => this._id;
+  ERG get erg => this._erg;
 
   Event({
-    this.status,
-    this.sId,
-    this.name,
-    this.venue,
-    this.startDate,
-    this.endDate,
-    this.createdAt,
-    this.updatedAt,
-    this.iV,
-    this.createdBy,
-    this.poster,
-    this.updatedBy,
-    this.onBehalfOf,
-    this.erg,
-    this.id,
-    this.slider,
-    this.trivia,
-  });
+    @required String sId,
+    @required String status,
+    @required String name,
+    @required String venue,
+    @required DateTime startDate,
+    @required DateTime endDate,
+    @required DateTime createdAt,
+    @required DateTime updatedAt,
+    @required int iV,
+    @required String onBehalfOf,
+    @required AdminUser createdBy,
+    @required ImageFile poster,
+    @required AdminUser updatedBy,
+    @required ERG erg,
+    @required String id,
+    @required String trivia,
+    @required bool slider,
+  })  : _sId = sId,
+        _status = status,
+        _name = name,
+        _venue = venue,
+        _startDate = startDate,
+        _endDate = endDate,
+        _createdAt = createdAt,
+        _updatedAt = updatedAt,
+        _iV = iV,
+        _onBehalfOf = onBehalfOf,
+        _createdBy = createdBy,
+        _poster = poster,
+        _updatedBy = updatedBy,
+        _erg = erg,
+        _id = id,
+        _trivia = trivia,
+        _slider = slider;
 
-  Event.fromJson(Map<String, dynamic> json) {
-    status = json['status'];
-    sId = json['_id'];
-    name = json['name'];
-    venue = json['venue'];
-    onBehalfOf = json['onBehalfOf'];
-    endDate = json['endDate'] != null
-        ? DateTime.parse((json['endDate'])).toLocal()
-        : null;
-    startDate = json['startDate'] != null
-        ? DateTime.parse((json['startDate'])).toLocal()
-        : null;
-    createdAt =
-        json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
-    updatedAt =
-        json['updatedAt'] != null ? DateTime.parse((json['updatedAt'])) : null;
-    iV = json['__v'];
-    createdBy = json['created_by'] != null
-        ? new AdminUser.fromJson(json['created_by'])
-        : null;
-    poster =
-        json['poster'] != null ? new ImageFile.fromJson(json['poster']) : null;
-    updatedBy = json['updated_by'] != null
-        ? new AdminUser.fromJson(json['updated_by'])
-        : null;
-    erg = json['erg'] != null ? new ERG.fromJson(json['erg']) : null;
-    id = json['id'];
-    slider = json['slider'] ?? false;
-    trivia = json['trivia'];
+  factory Event.fromJson(Map<String, dynamic> json) {
+    return Event(
+      status: json['status'],
+      sId: json['_id'],
+      name: json['name'],
+      venue: json['venue'],
+      onBehalfOf: json['onBehalfOf'],
+      erg: json['erg'] != null ? ERG.fromJson(json['erg']) : null,
+      id: json['id'],
+      slider: json['slider'] ?? false,
+      trivia: json['trivia'],
+      endDate: json['endDate'] != null
+          ? DateTime.parse((json['endDate'])).toLocal()
+          : null,
+      startDate: json['startDate'] != null
+          ? DateTime.parse((json['startDate'])).toLocal()
+          : null,
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse((json['createdAt']))
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse((json['updatedAt']))
+          : null,
+      iV: json['__v'],
+      createdBy: json['created_by'] != null
+          ? new AdminUser.fromJson(json['created_by'])
+          : null,
+      poster:
+          json['poster'] != null ? ImageFile.fromJson(json['poster']) : null,
+      updatedBy: json['updated_by'] != null
+          ? AdminUser.fromJson(json['updated_by'])
+          : null,
+    );
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
-    data['status'] = this.status;
-    data['_id'] = this.sId;
-    data['name'] = this.name;
-    data['venue'] = this.venue;
-    data['onBehalfOf'] = this.onBehalfOf;
-    data['startDate'] = this.startDate;
-    data['endDate'] = this.endDate;
-    data['createdAt'] = this.createdAt;
-    data['updatedAt'] = this.updatedAt;
-    data['__v'] = this.iV;
-    data['slider'] = this.slider;
-    if (this.createdBy != null) {
-      data['created_by'] = this.createdBy.toJson();
+    data['status'] = this._status;
+    data['_id'] = this._sId;
+    data['name'] = this._name;
+    data['venue'] = this._venue;
+    data['onBehalfOf'] = this._onBehalfOf;
+    data['startDate'] = this._startDate;
+    data['endDate'] = this._endDate;
+    data['createdAt'] = this._createdAt;
+    data['updatedAt'] = this._updatedAt;
+    data['__v'] = this._iV;
+    data['slider'] = this._slider;
+    if (this._createdBy != null) {
+      data['created_by'] = this._createdBy.toJson();
     }
-    if (this.poster != null) {
-      data['poster'] = this.poster.toJson();
+    if (this._poster != null) {
+      data['poster'] = this._poster.toJson();
     }
-    if (this.updatedBy != null) {
-      data['updated_by'] = this.updatedBy.toJson();
+    if (this._updatedBy != null) {
+      data['updated_by'] = this._updatedBy.toJson();
     }
-    if (this.erg != null) {
-      data['erg'] = this.erg.toJson();
+    if (this._erg != null) {
+      data['erg'] = this._erg.toJson();
     }
 
-    data['trivia'] = this.trivia;
-    data['id'] = this.id;
-    data['slider'] = this.slider;
+    data['trivia'] = this._trivia;
+    data['id'] = this._id;
+    data['slider'] = this._slider;
     return data;
   }
 }

--- a/lib/models/occurrence.dart
+++ b/lib/models/occurrence.dart
@@ -1,3 +1,4 @@
+import 'package:connect_plus/models/erg.dart';
 import 'package:connect_plus/models/image_file.dart';
 
 abstract class Occurrence {
@@ -6,4 +7,5 @@ abstract class Occurrence {
   ImageFile get poster;
   DateTime get date;
   bool get slider;
+  ERG get erg;
 }

--- a/lib/models/occurrence.dart
+++ b/lib/models/occurrence.dart
@@ -1,0 +1,9 @@
+import 'package:connect_plus/models/image_file.dart';
+
+abstract class Occurrence {
+  String get name;
+  String get sId;
+  ImageFile get poster;
+  DateTime get date;
+  bool get slider;
+}

--- a/lib/models/offer.dart
+++ b/lib/models/offer.dart
@@ -2,103 +2,154 @@ import 'package:connect_plus/models/admin_user.dart';
 import 'package:connect_plus/models/attachment.dart';
 import 'package:connect_plus/models/category.dart';
 import 'package:connect_plus/models/image_file.dart';
+import 'package:connect_plus/models/occurrence.dart';
+import 'package:meta/meta.dart';
 
-class Offer {
-  String sId;
-  String name;
-  Category category;
-  String details;
-  String discount;
-  DateTime expiration;
-  String contact;
-  DateTime createdAt;
-  DateTime updatedAt;
-  int iV;
-  AdminUser createdBy;
-  ImageFile logo;
-  AdminUser updatedBy;
-  String location;
-  Attachment attachment;
-  String id;
+class Offer extends Occurrence {
+  final String _sId;
+  final String _name;
+  final Category _category;
+  final String _details;
+  final String _discount;
+  final DateTime _expiration;
+  final String _contact;
+  final DateTime _createdAt;
+  final DateTime _updatedAt;
+  final int _iV;
+  final AdminUser _createdBy;
+  final ImageFile _logo;
+  final AdminUser _updatedBy;
+  final String _location;
+  final Attachment _attachment;
+  final String _id;
+  final bool _slider;
+
+  @override
+  String get sId => _sId;
+  @override
+  String get name => _name;
+  @override
+  DateTime get date => _createdAt;
+  @override
+  ImageFile get poster => _logo;
+  @override
+  bool get slider => _slider;
+
+  Category get category => _category;
+  String get details => _details;
+  String get discount => _discount;
+  DateTime get expiration => _expiration;
+  String get contact => _contact;
+  DateTime get createdAt => _createdAt;
+  DateTime get updatedAt => _updatedAt;
+  int get iV => _iV;
+  AdminUser get createdBy => _createdBy;
+  ImageFile get logo => _logo;
+  AdminUser get updatedBy => _updatedBy;
+  String get location => _location;
+  Attachment get attachment => _attachment;
+  String get id => _id;
 
   Offer({
-    this.sId,
-    this.name,
-    this.category,
-    this.details,
-    this.discount,
-    this.expiration,
-    this.contact,
-    this.createdAt,
-    this.updatedAt,
-    this.iV,
-    this.createdBy,
-    this.logo,
-    this.updatedBy,
-    this.location,
-    this.attachment,
-    this.id,
-  });
+    @required String sId,
+    @required String name,
+    @required Category category,
+    @required String details,
+    @required String discount,
+    @required DateTime expiration,
+    @required String contact,
+    @required DateTime createdAt,
+    @required DateTime updatedAt,
+    @required int iV,
+    @required AdminUser createdBy,
+    @required ImageFile logo,
+    @required AdminUser updatedBy,
+    @required String location,
+    @required Attachment attachment,
+    @required String id,
+    @required bool slider,
+  })  : _sId = sId,
+        _name = name,
+        _category = category,
+        _details = details,
+        _discount = discount,
+        _expiration = expiration,
+        _contact = contact,
+        _createdAt = createdAt,
+        _updatedAt = updatedAt,
+        _iV = iV,
+        _createdBy = createdBy,
+        _logo = logo,
+        _updatedBy = updatedBy,
+        _location = location,
+        _attachment = attachment,
+        _id = id,
+        _slider = slider;
 
-  Offer.fromJson(Map<String, dynamic> json) {
-    sId = json['_id'];
-    name = json['name'];
-    category = json['category'] != null
-        ? new Category.fromJson(json['category'])
-        : null;
-    details = json['details'];
-    discount = json['discount'];
-    expiration = json['expiration'] != null
-        ? DateTime.parse((json['expiration']))
-        : null;
-    contact = json['contact'];
-    createdAt =
-        json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
-    updatedAt =
-        json['updatedAt'] != null ? DateTime.parse((json['updatedAt'])) : null;
-    iV = json['__v'];
-    createdBy = json['created_by'] != null
-        ? new AdminUser.fromJson(json['created_by'])
-        : null;
-    logo = json['logo'] != null ? new ImageFile.fromJson(json['logo']) : null;
-    updatedBy = json['updated_by'] != null
-        ? new AdminUser.fromJson(json['updated_by'])
-        : null;
-    location = json['location'];
-    attachment = json['attachment'] != null
-        ? new Attachment.fromJson(json['attachment'])
-        : null;
-    id = json['id'];
+  factory Offer.fromJson(Map<String, dynamic> json) {
+    return Offer(
+      sId: json['_id'],
+      name: json['name'],
+      category: json['category'] != null
+          ? new Category.fromJson(json['category'])
+          : null,
+      details: json['details'],
+      discount: json['discount'],
+      expiration: json['expiration'] != null
+          ? DateTime.parse((json['expiration']))
+          : null,
+      contact: json['contact'],
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse((json['createdAt']))
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse((json['updatedAt']))
+          : null,
+      iV: json['__v'],
+      createdBy: json['created_by'] != null
+          ? new AdminUser.fromJson(json['created_by'])
+          : null,
+      logo: json['logo'] != null ? new ImageFile.fromJson(json['logo']) : null,
+      updatedBy: json['updated_by'] != null
+          ? new AdminUser.fromJson(json['updated_by'])
+          : null,
+      location: json['location'],
+      attachment: json['attachment'] != null
+          ? new Attachment.fromJson(json['attachment'])
+          : null,
+      id: json['id'],
+      slider: json['slider'] ?? false,
+    );
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
-    data['_id'] = this.sId;
-    data['name'] = this.name;
-    data['details'] = this.details;
-    data['discount'] = this.discount;
-    data['expiration'] = this.expiration.toIso8601String();
-    data['contact'] = this.contact;
-    data['createdAt'] = this.createdAt.toIso8601String();
-    data['updatedAt'] = this.updatedAt.toIso8601String();
-    data['__v'] = this.iV;
-    if (this.createdBy != null) {
-      data['created_by'] = this.createdBy.toJson();
+    data['_id'] = this._sId;
+    data['name'] = this._name;
+    data['details'] = this._details;
+    data['discount'] = this._discount;
+    data['expiration'] = this._expiration.toIso8601String();
+    data['contact'] = this._contact;
+    data['createdAt'] = this._createdAt.toIso8601String();
+    data['updatedAt'] = this._updatedAt.toIso8601String();
+    data['__v'] = this._iV;
+    if (this._createdBy != null) {
+      data['created_by'] = this._createdBy.toJson();
     }
-    if (this.logo != null) {
-      data['logo'] = this.logo.toJson();
+    if (this._logo != null) {
+      data['logo'] = this._logo.toJson();
     }
-    if (this.updatedBy != null) {
-      data['updated_by'] = this.updatedBy.toJson();
+    if (this._updatedBy != null) {
+      data['updated_by'] = this._updatedBy.toJson();
     }
-    data['location'] = this.location;
-    if (this.attachment != null) {
-      data['attachment'] = this.attachment.toJson();
+    data['location'] = this._location;
+    if (this._attachment != null) {
+      data['attachment'] = this._attachment.toJson();
     }
-    if (this.category != null) {
-      data['category'] = this.category.toJson();
+    if (this._category != null) {
+      data['category'] = this._category.toJson();
     }
-    data['id'] = this.id;
+    data['id'] = this._id;
     return data;
   }
 }

--- a/lib/models/offer.dart
+++ b/lib/models/offer.dart
@@ -1,6 +1,7 @@
 import 'package:connect_plus/models/admin_user.dart';
 import 'package:connect_plus/models/attachment.dart';
 import 'package:connect_plus/models/category.dart';
+import 'package:connect_plus/models/erg.dart';
 import 'package:connect_plus/models/image_file.dart';
 import 'package:connect_plus/models/occurrence.dart';
 import 'package:meta/meta.dart';
@@ -23,6 +24,7 @@ class Offer extends Occurrence {
   final Attachment _attachment;
   final String _id;
   final bool _slider;
+  final ERG _erg;
 
   @override
   String get sId => _sId;
@@ -34,6 +36,8 @@ class Offer extends Occurrence {
   ImageFile get poster => _logo;
   @override
   bool get slider => _slider;
+  @override
+  ERG get erg => _erg;
 
   Category get category => _category;
   String get details => _details;
@@ -68,6 +72,7 @@ class Offer extends Occurrence {
     @required Attachment attachment,
     @required String id,
     @required bool slider,
+    @required ERG erg,
   })  : _sId = sId,
         _name = name,
         _category = category,
@@ -84,7 +89,8 @@ class Offer extends Occurrence {
         _location = location,
         _attachment = attachment,
         _id = id,
-        _slider = slider;
+        _slider = slider,
+        _erg = erg;
 
   factory Offer.fromJson(Map<String, dynamic> json) {
     return Offer(
@@ -119,6 +125,7 @@ class Offer extends Occurrence {
           : null,
       id: json['id'],
       slider: json['slider'] ?? false,
+      erg: json['erg'] != null ? ERG.fromJson(json['erg']) : null,
     );
   }
 
@@ -149,7 +156,11 @@ class Offer extends Occurrence {
     if (this._category != null) {
       data['category'] = this._category.toJson();
     }
+    if (this._erg != null) {
+      data['erg'] = this._erg.toJson();
+    }
     data['id'] = this._id;
+
     return data;
   }
 }

--- a/lib/models/webinar.dart
+++ b/lib/models/webinar.dart
@@ -1,104 +1,152 @@
 import 'package:connect_plus/models/admin_user.dart';
 import 'package:connect_plus/models/erg.dart';
 import 'package:connect_plus/models/image_file.dart';
+import 'package:connect_plus/models/occurrence.dart';
+import 'package:flutter/foundation.dart';
 
-class Webinar {
-  String sId;
-  String name;
-  String url;
-  double duration;
-  DateTime startDate;
-  DateTime createdAt;
-  DateTime updatedAt;
-  String onBehalfOf;
-  int iV;
-  AdminUser createdBy;
-  ERG erg;
-  ImageFile poster;
-  AdminUser updatedBy;
-  String id;
-  bool isRecorded;
-  String trivia;
-  bool slider;
+class Webinar extends Occurrence {
+  final String _sId;
+  final String _name;
+  final String _url;
+  final double _duration;
+  final DateTime _startDate;
+  final DateTime _createdAt;
+  final DateTime _updatedAt;
+  final String _onBehalfOf;
+  final int _iV;
+  final AdminUser _createdBy;
+  final ERG _erg;
+  final ImageFile _poster;
+  final AdminUser _updatedBy;
+  final String _id;
+  final bool _isRecorded;
+  final String _trivia;
+  final bool _slider;
+
+  @override
+  String get sId => _sId;
+  @override
+  String get name => _name;
+  @override
+  ImageFile get poster => _poster;
+  @override
+  bool get slider => _slider;
+  @override
+  DateTime get date => _createdAt;
+
+  String get url => _url;
+  double get duration => _duration;
+  DateTime get startDate => _startDate;
+  DateTime get createdAt => _createdAt;
+  DateTime get updatedAt => _updatedAt;
+  String get onBehalfOf => _onBehalfOf;
+  int get iV => _iV;
+  AdminUser get createdBy => _createdBy;
+  AdminUser get updatedBy => _updatedBy;
+  ERG get erg => _erg;
+  String get id => _id;
+  bool get isRecorded => _isRecorded;
+  String get trivia => _trivia;
 
   Webinar({
-    this.sId,
-    this.name,
-    this.url,
-    this.duration,
-    this.startDate,
-    this.createdAt,
-    this.onBehalfOf,
-    this.updatedAt,
-    this.iV,
-    this.createdBy,
-    this.erg,
-    this.poster,
-    this.updatedBy,
-    this.isRecorded,
-    this.id,
-    this.slider,
-    this.trivia,
-  });
+    @required String sId,
+    @required String name,
+    @required String url,
+    @required double duration,
+    @required DateTime startDate,
+    @required DateTime createdAt,
+    @required String onBehalfOf,
+    @required DateTime updatedAt,
+    @required int iV,
+    @required AdminUser createdBy,
+    @required ERG erg,
+    @required ImageFile poster,
+    @required AdminUser updatedBy,
+    @required bool isRecorded,
+    @required String id,
+    @required bool slider,
+    @required String trivia,
+  })  : _sId = sId,
+        _name = name,
+        _url = url,
+        _duration = duration,
+        _startDate = startDate,
+        _createdAt = createdAt,
+        _onBehalfOf = onBehalfOf,
+        _updatedAt = updatedAt,
+        _iV = iV,
+        _createdBy = createdBy,
+        _erg = erg,
+        _poster = poster,
+        _updatedBy = updatedBy,
+        _isRecorded = isRecorded,
+        _id = id,
+        _slider = slider,
+        _trivia = trivia;
 
-  Webinar.fromJson(Map<String, dynamic> json) {
-    sId = json['_id'];
-    name = json['name'];
-    url = json['url'];
-    onBehalfOf = json['onBehalfOf'];
-    isRecorded = json['isRecorded'];
-    duration = double.parse(json['Duration'].toString());
-    startDate = json['startDate'] != null
-        ? DateTime.parse((json['startDate'])).toLocal()
-        : null;
-    createdAt =
-        json['createdAt'] != null ? DateTime.parse((json['createdAt'])) : null;
-    updatedAt =
-        json['updatedAt'] != null ? DateTime.parse((json['updatedAt'])) : null;
-    iV = json['__v'];
-    createdBy = json['created_by'] != null
-        ? new AdminUser.fromJson(json['created_by'])
-        : null;
-    poster =
-        json['poster'] != null ? new ImageFile.fromJson(json['poster']) : null;
-    updatedBy = json['updated_by'] != null
-        ? new AdminUser.fromJson(json['updated_by'])
-        : null;
-    erg = json['erg'] != null ? new ERG.fromJson(json['erg']) : null;
-    id = json['id'];
-    slider = json['slider'] ?? false;
-    trivia = json['trivia']; // will auto set to null
+  factory Webinar.fromJson(Map<String, dynamic> json) {
+    return Webinar(
+      sId: json['_id'],
+      name: json['name'],
+      url: json['url'],
+      onBehalfOf: json['onBehalfOf'],
+      isRecorded: json['isRecorded'],
+      duration: double.parse(json['Duration'].toString()),
+      startDate: json['startDate'] != null
+          ? DateTime.parse((json['startDate'])).toLocal()
+          : null,
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse((json['createdAt']))
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse((json['updatedAt']))
+          : null,
+      iV: json['__v'],
+      createdBy: json['created_by'] != null
+          ? new AdminUser.fromJson(json['created_by'])
+          : null,
+      poster: json['poster'] != null
+          ? new ImageFile.fromJson(json['poster'])
+          : null,
+      updatedBy: json['updated_by'] != null
+          ? new AdminUser.fromJson(json['updated_by'])
+          : null,
+      erg: json['erg'] != null ? new ERG.fromJson(json['erg']) : null,
+      id: json['id'],
+      slider: json['slider'] ?? false,
+      trivia: json['trivia'], // will auto set to null
+    );
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
-    data['_id'] = this.sId;
-    data['name'] = this.name;
-    data['onBehalfOf'] = this.onBehalfOf;
-    data['url'] = this.url;
-    data['Duration'] = this.duration;
-    data['startDate'] = this.startDate;
-    data['createdAt'] = this.createdAt;
-    data['updatedAt'] = this.updatedAt;
-    data['isRecorded'] = this.isRecorded;
-    data['slider'] = this.slider;
-    data['__v'] = this.iV;
-    if (this.createdBy != null) {
-      data['created_by'] = this.createdBy.toJson();
+    data['_id'] = this._sId;
+    data['name'] = this._name;
+    data['onBehalfOf'] = this._onBehalfOf;
+    data['url'] = this._url;
+    data['Duration'] = this._duration;
+    data['startDate'] = this._startDate;
+    data['createdAt'] = this._createdAt;
+    data['updatedAt'] = this._updatedAt;
+    data['isRecorded'] = this._isRecorded;
+    data['slider'] = this._slider;
+    data['__v'] = this._iV;
+    if (this._createdBy != null) {
+      data['created_by'] = this._createdBy.toJson();
     }
-    if (this.erg != null) {
-      data['erg'] = this.erg.toJson();
+    if (this._erg != null) {
+      data['erg'] = this._erg.toJson();
     }
-    if (this.poster != null) {
-      data['poster'] = this.poster.toJson();
+    if (this._poster != null) {
+      data['poster'] = this._poster.toJson();
     }
-    if (this.updatedBy != null) {
-      data['updated_by'] = this.updatedBy.toJson();
+    if (this._updatedBy != null) {
+      data['updated_by'] = this._updatedBy.toJson();
     }
 
-    data['trivia'] = this.trivia;
-    data['id'] = this.id;
-    data['slider'] = this.slider;
+    data['trivia'] = this._trivia;
+    data['id'] = this._id;
+    data['slider'] = this._slider;
     return data;
   }
 }


### PR DESCRIPTION
## Add announcements, offers, and activities to homepage carousel slider
Add two announcements from "internal comms", and add offers/activities to the homepage carousel slider pool per ERG. Both would be selected according to the latest deadline/expiration. 

This should function along with previous functionality of the carousel slider including manual additions and ERG events/webinars

**Overall Functionality**
The carousel should show max of:
- 2 announcements from Internal Comms
- 1 Event/Webinar/Activity from Internal Comms
- 1 Event/Webinar/Activity from each ERG

### Tasks
- [x] Create a superclass for `Announcement`, `Offer`, `Event`, and `Activity`
- [x] Add the latest 2 announcements from Internal Comms to the homepage carousel
- [x] Add offers and activities to the pool of selected posters per ERG for the home page carousel