### PR TITLE
Bugfix 177344270 minor bug fixes

### DIFF
--- a/lib/AnnouncementVariables.dart
+++ b/lib/AnnouncementVariables.dart
@@ -103,7 +103,7 @@ class Single_Announcement extends StatelessWidget {
       height: height,
       child: Card(
         child: Hero(
-          tag: announcement.name,
+          tag: announcement.id,
           child: Material(
             child: InkWell(
               onTap: () {

--- a/lib/EventsVariable.dart
+++ b/lib/EventsVariable.dart
@@ -169,7 +169,7 @@ class Single_Event extends StatelessWidget {
         height: height,
         child: Card(
           child: Hero(
-            tag: event.name,
+            tag: event.id,
             child: Material(
               child: InkWell(
                 onTap: () {

--- a/lib/OfferVariables.dart
+++ b/lib/OfferVariables.dart
@@ -135,18 +135,20 @@ class Single_Offer extends StatelessWidget {
                           offer.name,
                           style: TextStyle(fontWeight: FontWeight.bold),
                         ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            Text("Expires: "),
-                            Text(
-                              DateFormat.yMMMMd('en_US')
-                                  .format(offer.expiration),
-                              style: TextStyle(
-                                  color: Colors.red,
-                                  fontWeight: FontWeight.w800),
-                            ),
-                          ],
+                        FittedBox(
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              Text("Expires: "),
+                              Text(
+                                DateFormat.yMMMMd('en_US')
+                                    .format(offer.expiration),
+                                style: TextStyle(
+                                    color: Colors.red,
+                                    fontWeight: FontWeight.w800),
+                              ),
+                            ],
+                          ),
                         )
                       ],
                     ),

--- a/lib/OfferVariables.dart
+++ b/lib/OfferVariables.dart
@@ -111,7 +111,7 @@ class Single_Offer extends StatelessWidget {
       height: height,
       child: Card(
         child: Hero(
-          tag: offer.name,
+          tag: offer.id,
           child: Material(
             child: InkWell(
               onTap: () {

--- a/lib/announcement_widget.dart
+++ b/lib/announcement_widget.dart
@@ -23,13 +23,13 @@ class AnnouncementWidget extends StatelessWidget {
         backgroundColor: Colors.transparent,
       ),
       body: Container(
-        padding: const EdgeInsets.only(top: 100),
+        padding: const EdgeInsets.only(top: 112),
         height: MediaQuery.of(context).size.height,
         width: MediaQuery.of(context).size.width,
         decoration: BoxDecoration(
           gradient: LinearGradient(
             begin: Alignment.topRight,
-            end: Alignment.bottomLeft,
+            end: Alignment.topLeft,
             colors: [
               Utils.secondaryColor,
               Utils.primaryColor,
@@ -62,8 +62,11 @@ class AnnouncementImage extends StatelessWidget {
   final Announcement announcement;
   @override
   Widget build(BuildContext context) {
-    return CachedImageBox(
-      imageurl: WebAPI.baseURL + announcement.poster.url,
+    return Container(
+      padding: const EdgeInsets.fromLTRB(25, 7, 25, 7),
+      child: CachedImageBox(
+        imageurl: WebAPI.baseURL + announcement.poster.url,
+      ),
     );
   }
 }

--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -77,8 +77,14 @@ class _AnnouncementsState extends State<Announcements> {
                 toSuggest: (pattern) {
                   if (pattern == "") return null;
                   return announcements
-                      .where((a) => filter(a) && a.name.startsWith(pattern))
-                      .take(5); // suggests only 5
+                      .where(
+                        (a) =>
+                            filter(a) &&
+                            a.name
+                                .toLowerCase()
+                                .startsWith(pattern.toLowerCase()),
+                      )
+                      .take(5); // suggests only 5 results
                 },
               ),
               preferredSize: Size.fromHeight(kToolbarHeight + 10),

--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:connect_plus/widgets/CachedImageBox.dart';
 import 'package:connect_plus/models/announcement.dart';
 import 'package:connect_plus/services/web_api.dart';
+import 'package:connect_plus/widgets/ImageRotate.dart';
 import 'package:connect_plus/widgets/Utils.dart';
 import 'package:filter_list/filter_list.dart';
 import 'package:flutter/material.dart';
@@ -58,7 +59,7 @@ class _AnnouncementsState extends State<Announcements> {
     return FutureBuilder<List<Announcement>>(
       future: _getAnnouncements(),
       builder: (context, snapshot) {
-        if (!snapshot.hasData) return Scaffold(body: LoadingIndicator());
+        if (!snapshot.hasData) return Scaffold(body: ImageRotate());
         final List<Announcement> announcements = snapshot.data;
         return Scaffold(
           floatingActionButton: FloatingActionButton(

--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -26,7 +26,7 @@ class _AnnouncementsState extends State<Announcements> {
         : onBehalfOfFilter;
     return await FilterListDialog.display(
       context,
-      allTextList: announcements.map((a) => a.onBehalfOf).toList(),
+      allTextList: announcements.map((a) => a.onBehalfOf).toSet().toList(),
       height: 480,
       borderRadius: 20,
       headlineText: "Select Announcements on Behalf of",
@@ -49,7 +49,8 @@ class _AnnouncementsState extends State<Announcements> {
 
     if (onBehalfOfFilter == null) {
       // will only run once
-      onBehalfOfFilter = announcements.map((a) => a.onBehalfOf).toList();
+      onBehalfOfFilter =
+          announcements.map((a) => a.onBehalfOf).toSet().toList();
     }
     return announcements;
   }

--- a/lib/announcements.dart
+++ b/lib/announcements.dart
@@ -21,9 +21,6 @@ class _AnnouncementsState extends State<Announcements> {
   }
 
   Future<void> _showFilters(List<Announcement> announcements) async {
-    final selectedFilters = onBehalfOfFilter.isEmpty
-        ? announcements.map((a) => a.onBehalfOf).toList()
-        : onBehalfOfFilter;
     return await FilterListDialog.display(
       context,
       allTextList: announcements.map((a) => a.onBehalfOf).toSet().toList(),
@@ -34,7 +31,7 @@ class _AnnouncementsState extends State<Announcements> {
       allResetButonColor: Utils.header,
       selectedTextBackgroundColor: Utils.header,
       searchFieldHintText: "Search Here",
-      selectedTextList: selectedFilters,
+      selectedTextList: onBehalfOfFilter,
       onApplyButtonClick: (onBehalfOfFilterList) {
         setState(() {
           onBehalfOfFilter = onBehalfOfFilterList;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,9 @@ import 'package:connect_plus/services/auth_service/auth_service.dart';
 import 'package:connect_plus/models/user.dart';
 
 Future main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await DotEnv().load('.env');
+  await Firebase.initializeApp();
   runApp(MyApp());
 }
 
@@ -23,8 +25,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  // TODO: move to injection container
-  final Future<FirebaseApp> _initialization = Firebase.initializeApp();
   @override
   void initState() {
     di.init();
@@ -33,32 +33,18 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-        // Initialize FlutterFire:
-        future: _initialization,
-        builder: (context, snapshot) {
-          versionCheck(context);
-          if (snapshot.hasError) {
-            return Splash();
-          }
-
-          // Once complete, show your application
-          if (snapshot.connectionState == ConnectionState.done) {
-            return GetMaterialApp(
-              title: 'Connect+',
-              debugShowCheckedModeBanner: false,
-              navigatorKey: NavigationService.navigationKey,
-              routes: Routes.routes,
-              theme: ThemeData(
-                fontFamily: 'Roboto',
-                primarySwatch: Colors.deepOrange,
-                visualDensity: VisualDensity.adaptivePlatformDensity,
-              ),
-              home: Splash(),
-            );
-          }
-          return Splash();
-        });
+    return GetMaterialApp(
+      title: 'Connect+',
+      debugShowCheckedModeBanner: false,
+      navigatorKey: NavigationService.navigationKey,
+      routes: Routes.routes,
+      theme: ThemeData(
+        fontFamily: 'Roboto',
+        primarySwatch: Colors.deepOrange,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+      ),
+      home: Splash(),
+    );
   }
 }
 

--- a/lib/widgets/CachedImageBox.dart
+++ b/lib/widgets/CachedImageBox.dart
@@ -7,7 +7,13 @@ class CachedImageBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CachedNetworkImage(
-      placeholder: (context, url) => Container(color: Colors.grey[300]),
+      placeholder: (context, url) => Center(
+        child: SizedBox(
+          height: 40,
+          width: 40,
+          child: CircularProgressIndicator(),
+        ),
+      ),
       imageUrl: imageurl,
       fit: BoxFit.fill,
     );

--- a/lib/widgets/CachedImageBox.dart
+++ b/lib/widgets/CachedImageBox.dart
@@ -7,9 +7,7 @@ class CachedImageBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CachedNetworkImage(
-      placeholder: (context, url) => Expanded(
-        child: Container(color: Colors.grey[300]),
-      ),
+      placeholder: (context, url) => Container(color: Colors.grey[300]),
       imageUrl: imageurl,
       fit: BoxFit.fill,
     );


### PR DESCRIPTION
## Fixed
- [x] Circular loading indicators taking up the whole screen instead of being size constrained
- [x] Multiple exceptions thrown on app launch
- [x] Pixel overflow in recent offers in the homepage on some devices (tested on iPhone 11) 
- [x] In the announcements list screen, clicking "Reset" in the filter, then "Apply", then reopening the filter shows all filters are selected, when they should be unselected 
- [x] Announcements, events, and offers with the same name cause the app to break (Change Hero tag from item `name` to `id`)
- [x] Announcements search bar should not be case sensitive
- [x] When more than one announcement have the `onBehalfOf` value, the search filter duplicates that value 