### PR TITLE
Bugfix 177961393 change car plate tooltip

### DIFF
--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -530,7 +530,7 @@ class CarPlateInputTitle extends StatelessWidget {
           },
           child: Tooltip(
             key: _toolTipKey,
-            message: "Text should be in Arabic only",
+            message: "Car plate data will be used for move your car feature",
             preferBelow: false,
             child: Icon(
               Icons.info_outline,


### PR DESCRIPTION
## Description 
As a user, I want to know why my car plate number is needed in registration.

Change disclaimer from 'Please use arabic words' to 'Car plate data will be used for move your car feature'