### PR TITLE
Feature 178111491 edit business unit in profile

### DIFF
--- a/lib/BusinessUnit.dart
+++ b/lib/BusinessUnit.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:connect_plus/widgets/Utils.dart';
+import 'package:connect_plus/services/web_api.dart';
+
+class BusinessUnit extends StatefulWidget {
+  BusinessUnit({Key key, this.PassValue}) : super(key: key);
+  final void Function(String value) PassValue;
+  @override
+  _BusinessUnit createState() => _BusinessUnit();
+}
+
+class _BusinessUnit extends State<BusinessUnit> {
+  String dropdownValue = 'one';
+  bool Loaded = false;
+  List<String> BUs = new List<String>();
+  void _getBusinessUnits() async {
+    BUs = await WebAPI.getBusinessUnits();
+    setState(() {
+      Loaded = true;
+    });
+    print(BUs);
+  }
+
+  void initState() {
+    _getBusinessUnits();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Loaded
+        ? DropdownButton<String>(
+            value: BUs[0],
+            icon: const Icon(Icons.arrow_downward),
+            iconSize: 24,
+            elevation: 16,
+            style: const TextStyle(
+              color: Utils.header,
+            ),
+            underline: Container(
+              height: 2,
+              color: Utils.header,
+            ),
+            onChanged: (String newValue) {
+              setState(() {
+                dropdownValue = newValue;
+                widget.PassValue(dropdownValue);
+              });
+            },
+            items: BUs.map<DropdownMenuItem<String>>((String value) {
+              return DropdownMenuItem<String>(
+                value: value,
+                child: Text(value),
+              );
+            }).toList(),
+          )
+        : Container();
+  }
+}

--- a/lib/BusinessUnit.dart
+++ b/lib/BusinessUnit.dart
@@ -3,8 +3,11 @@ import 'package:connect_plus/widgets/Utils.dart';
 import 'package:connect_plus/services/web_api.dart';
 
 class BusinessUnit extends StatefulWidget {
-  BusinessUnit({Key key, this.PassValue}) : super(key: key);
+  BusinessUnit({Key key, this.PassValue, this.asyncCallController})
+      : super(key: key);
   final void Function(String value) PassValue;
+  final void Function(bool value) asyncCallController;
+
   @override
   _BusinessUnit createState() => _BusinessUnit();
 }
@@ -15,6 +18,9 @@ class _BusinessUnit extends State<BusinessUnit> {
   List<String> BUs = new List<String>();
   void _getBusinessUnits() async {
     BUs = await WebAPI.getBusinessUnits();
+    widget.asyncCallController(false);
+    dropdownValue = BUs[0];
+    print(dropdownValue);
     setState(() {
       Loaded = true;
     });
@@ -22,6 +28,8 @@ class _BusinessUnit extends State<BusinessUnit> {
   }
 
   void initState() {
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => {widget.asyncCallController(true)});
     _getBusinessUnits();
   }
 
@@ -29,7 +37,7 @@ class _BusinessUnit extends State<BusinessUnit> {
   Widget build(BuildContext context) {
     return Loaded
         ? DropdownButton<String>(
-            value: BUs[0],
+            value: dropdownValue,
             icon: const Icon(Icons.arrow_downward),
             iconSize: 24,
             elevation: 16,

--- a/lib/BusinessUnit.dart
+++ b/lib/BusinessUnit.dart
@@ -3,31 +3,37 @@ import 'package:connect_plus/widgets/Utils.dart';
 import 'package:connect_plus/services/web_api.dart';
 
 class BusinessUnit extends StatefulWidget {
-  BusinessUnit({Key key, this.PassValue, this.asyncCallController})
+  BusinessUnit({Key key, this.PassValue, this.asyncCallController, this.userBU})
       : super(key: key);
   final void Function(String value) PassValue;
   final void Function(bool value) asyncCallController;
+  final String userBU;
 
   @override
   _BusinessUnit createState() => _BusinessUnit();
 }
 
 class _BusinessUnit extends State<BusinessUnit> {
-  String dropdownValue = 'one';
+  String dropdownValue = '';
   bool Loaded = false;
   List<String> BUs = new List<String>();
+
   void _getBusinessUnits() async {
+    BUs = new List<String>();
     BUs = await WebAPI.getBusinessUnits();
     widget.asyncCallController(false);
-    dropdownValue = BUs[0];
-    print(dropdownValue);
+    if (dropdownValue == '') dropdownValue = BUs[0];
+    widget.PassValue(dropdownValue);
     setState(() {
       Loaded = true;
     });
-    print(BUs);
   }
 
   void initState() {
+    if (widget.userBU != null) {
+      dropdownValue = widget.userBU;
+      BUs.add(dropdownValue);
+    }
     WidgetsBinding.instance
         .addPostFrameCallback((_) => {widget.asyncCallController(true)});
     _getBusinessUnits();

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -14,6 +14,7 @@ import 'package:connect_plus/services/auth_service/auth_service.dart';
 import 'package:connect_plus/injection_container.dart';
 import 'package:connect_plus/BusinessUnit.dart';
 import 'package:modal_progress_hud/modal_progress_hud.dart';
+import 'package:connect_plus/widgets/ImageRotate.dart';
 
 class ProfilePage extends StatefulWidget {
   @override
@@ -181,7 +182,7 @@ class MapScreenState extends State<ProfilePage>
         body: ModalProgressHUD(
             inAsyncCall: _loading,
             opacity: 0.5,
-            progressIndicator: CircularProgressIndicator(),
+            progressIndicator: ImageRotate(),
             child: new Container(
               child: new ListView(
                 children: <Widget>[

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -13,6 +13,7 @@ import 'package:connect_plus/services/web_api.dart';
 import 'package:connect_plus/services/auth_service/auth_service.dart';
 import 'package:connect_plus/injection_container.dart';
 import 'package:connect_plus/BusinessUnit.dart';
+import 'package:modal_progress_hud/modal_progress_hud.dart';
 
 class ProfilePage extends StatefulWidget {
   @override
@@ -177,130 +178,138 @@ class MapScreenState extends State<ProfilePage>
             ),
           ),
         ),
-        body: new Container(
-          child: new ListView(
-            children: <Widget>[
-              Column(
+        body: ModalProgressHUD(
+            inAsyncCall: _loading,
+            opacity: 0.5,
+            progressIndicator: CircularProgressIndicator(),
+            child: new Container(
+              child: new ListView(
                 children: <Widget>[
-                  new Container(
-                    height: height * 0.23,
-                    child: new Column(
-                      children: <Widget>[
-                        Padding(
-                          padding: EdgeInsets.only(top: height * 0.05),
-                          child:
-                              new Stack(fit: StackFit.loose, children: <Widget>[
-                            new Row(
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: <Widget>[
-                                new Container(
-                                    width: width * 0.20,
-                                    height: height * 0.14,
-                                    decoration: new BoxDecoration(
-                                      image: new DecorationImage(
-                                        image: new ExactAssetImage(
-                                            'assets/as.png'),
-                                        fit: BoxFit.contain,
-                                      ),
-                                    )),
-                              ],
-                            ),
-                          ]),
-                        )
-                      ],
-                    ),
-                  ),
-                  new Container(
-                    color: Utils.background,
-                    child: Padding(
-                      padding: EdgeInsets.only(bottom: height * 0.03),
-                      child: new Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Padding(
-                              padding: EdgeInsets.only(right: width * 0.08),
-                              child: new Row(
-                                mainAxisAlignment: MainAxisAlignment.end,
-                                mainAxisSize: MainAxisSize.max,
-                                children: <Widget>[
-                                  new Column(
-                                    mainAxisAlignment: MainAxisAlignment.end,
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: <Widget>[
-                                      _notEditing
-                                          ? _getEditIcon()
-                                          : new Container(),
-                                    ],
-                                  )
-                                ],
-                              )),
-                          FutureBuilder<User>(
-                            future: sl<AuthService>().user,
-                            builder: (context, snapshot) {
-                              if (!snapshot.hasData) {
-                                return Center(
-                                  child: SizedBox(
-                                    height: 60,
-                                    width: 60,
-                                    child: CircularProgressIndicator(),
-                                  ),
-                                );
-                              }
-                              final user = snapshot.data;
-                              return Form(
-                                  key: _formKey,
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: <Widget>[
-                                      _getLabel("Full Name"),
-                                      _getField(user.username.toString(),
-                                          nameController, false),
-                                      _getLabel("Email"),
-                                      _getField(user.email.toString(),
-                                          emailController, true),
-                                      _getLabel("Phone Number"),
-                                      _getField(user.phoneNumber.toString(),
-                                          phoneController, false),
-                                      _getLabel("Car Plate"),
-                                      _notEditing
-                                          ? _getField(
-                                              user.carPlate,
-                                              carPlateController,
-                                              false,
-                                            )
-                                          : CarPlateForm(
-                                              carPlateController:
-                                                  carPlateController,
-                                              initialValue: user.carPlate,
-                                            ),
-                                      _getLabel("Business Unit"),
-                                      _notEditing
-                                          ? _getField(
-                                              user.businessUnit, null, false)
-                                          : BusinessUnitWidget(
-                                              userBu: user.businessUnit,
-                                              asyncCallController:
-                                                  _asyncCallController,
-                                            ),
-                                      !_notEditing
-                                          ? _getActionButtons(user)
-                                          : new Container(),
-                                    ],
-                                  ));
-                            },
-                          ),
-                        ],
+                  Column(
+                    children: <Widget>[
+                      new Container(
+                        height: height * 0.23,
+                        child: new Column(
+                          children: <Widget>[
+                            Padding(
+                              padding: EdgeInsets.only(top: height * 0.05),
+                              child: new Stack(
+                                  fit: StackFit.loose,
+                                  children: <Widget>[
+                                    new Row(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      children: <Widget>[
+                                        new Container(
+                                            width: width * 0.20,
+                                            height: height * 0.14,
+                                            decoration: new BoxDecoration(
+                                              image: new DecorationImage(
+                                                image: new ExactAssetImage(
+                                                    'assets/as.png'),
+                                                fit: BoxFit.contain,
+                                              ),
+                                            )),
+                                      ],
+                                    ),
+                                  ]),
+                            )
+                          ],
+                        ),
                       ),
-                    ),
-                  )
+                      new Container(
+                        color: Utils.background,
+                        child: Padding(
+                          padding: EdgeInsets.only(bottom: height * 0.03),
+                          child: new Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            children: <Widget>[
+                              Padding(
+                                  padding: EdgeInsets.only(right: width * 0.08),
+                                  child: new Row(
+                                    mainAxisAlignment: MainAxisAlignment.end,
+                                    mainAxisSize: MainAxisSize.max,
+                                    children: <Widget>[
+                                      new Column(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.end,
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: <Widget>[
+                                          _notEditing
+                                              ? _getEditIcon()
+                                              : new Container(),
+                                        ],
+                                      )
+                                    ],
+                                  )),
+                              FutureBuilder<User>(
+                                future: sl<AuthService>().user,
+                                builder: (context, snapshot) {
+                                  if (!snapshot.hasData) {
+                                    return Center(
+                                      child: SizedBox(
+                                        height: 60,
+                                        width: 60,
+                                        child: CircularProgressIndicator(),
+                                      ),
+                                    );
+                                  }
+                                  final user = snapshot.data;
+                                  return Form(
+                                      key: _formKey,
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: <Widget>[
+                                          _getLabel("Full Name"),
+                                          _getField(user.username.toString(),
+                                              nameController, false),
+                                          _getLabel("Email"),
+                                          _getField(user.email.toString(),
+                                              emailController, true),
+                                          _getLabel("Phone Number"),
+                                          _getField(user.phoneNumber.toString(),
+                                              phoneController, false),
+                                          _getLabel("Car Plate"),
+                                          _notEditing
+                                              ? _getField(
+                                                  user.carPlate,
+                                                  carPlateController,
+                                                  false,
+                                                )
+                                              : CarPlateForm(
+                                                  carPlateController:
+                                                      carPlateController,
+                                                  initialValue: user.carPlate,
+                                                ),
+                                          _getLabel("Business Unit"),
+                                          _notEditing
+                                              ? _getField(user.businessUnit,
+                                                  null, false)
+                                              : BusinessUnitWidget(
+                                                  userBu: user.businessUnit,
+                                                  asyncCallController:
+                                                      _asyncCallController,
+                                                ),
+                                          !_notEditing
+                                              ? _getActionButtons(user)
+                                              : new Container(),
+                                        ],
+                                      ));
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
                 ],
               ),
-            ],
-          ),
-        ));
+            )));
   }
 
   @override

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -23,6 +23,7 @@ class MapScreenState extends State<ProfilePage>
     with SingleTickerProviderStateMixin {
   final LocalStorage localStorage = new LocalStorage("Connect+");
   bool _notEditing = true;
+  bool _loading = false;
   final FocusNode myFocusNode = FocusNode();
 
   TextEditingController nameController = TextEditingController();
@@ -30,6 +31,12 @@ class MapScreenState extends State<ProfilePage>
   TextEditingController phoneController = TextEditingController();
   TextEditingController carPlateController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
+  void _asyncCallController(bool value) {
+    print(value);
+    setState(() {
+      _loading = value;
+    });
+  }
 
   //Missing validation that edit profile is success or a failure .. but tested it is working
   void editProfile() async {
@@ -275,6 +282,8 @@ class MapScreenState extends State<ProfilePage>
                                               user.businessUnit, null, false)
                                           : BusinessUnitWidget(
                                               userBu: user.businessUnit,
+                                              asyncCallController:
+                                                  _asyncCallController,
                                             ),
                                       !_notEditing
                                           ? _getActionButtons(user)
@@ -536,7 +545,7 @@ class BusinessUnitWidget extends StatelessWidget {
   }
 
   void onLoaded(bool val) {
-    //asyncCallController(val);
+    asyncCallController(val);
   }
 
   @override

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -269,6 +269,16 @@ class MapScreenState extends State<ProfilePage>
                                                   carPlateController,
                                               initialValue: user.carPlate,
                                             ),
+                                      _getLabel("Business Unit"),
+                                      _notEditing
+                                          ? _getField(
+                                              user.businessUnit, null, false)
+                                          : BusinessUnitWidget(
+                                              userBu: user.businessUnit,
+                                            ),
+                                      !_notEditing
+                                          ? _getActionButtons(user)
+                                          : new Container(),
                                     ],
                                   ));
                             },
@@ -526,7 +536,7 @@ class BusinessUnitWidget extends StatelessWidget {
   }
 
   void onLoaded(bool val) {
-    asyncCallController(val);
+    //asyncCallController(val);
   }
 
   @override

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -26,6 +26,7 @@ class MapScreenState extends State<ProfilePage>
   final LocalStorage localStorage = new LocalStorage("Connect+");
   bool _notEditing = true;
   bool _loading = false;
+  String _BusinessUnit = "";
   final FocusNode myFocusNode = FocusNode();
 
   TextEditingController nameController = TextEditingController();
@@ -37,6 +38,12 @@ class MapScreenState extends State<ProfilePage>
     print(value);
     setState(() {
       _loading = value;
+    });
+  }
+
+  void businessUnitController(String value) {
+    setState(() {
+      _BusinessUnit = value;
     });
   }
 
@@ -294,6 +301,8 @@ class MapScreenState extends State<ProfilePage>
                                                   userBu: user.businessUnit,
                                                   asyncCallController:
                                                       _asyncCallController,
+                                                  BusinessUnitController:
+                                                      businessUnitController,
                                                 ),
                                           !_notEditing
                                               ? _getActionButtons(user)
@@ -551,7 +560,7 @@ class BusinessUnitWidget extends StatelessWidget {
   }) : super(key: key);
 
   void onChange(String val) {
-    //BusinessUnitController(val);
+    BusinessUnitController(val);
   }
 
   void onLoaded(bool val) {

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -56,7 +56,7 @@ class MapScreenState extends State<ProfilePage>
           phoneNumber: phoneController.text == "" ? null : phoneController.text,
           carPlate:
               carPlateController.text == "" ? null : carPlateController.text,
-          //businessUnit: businessUnitController
+          businessUnit: _BusinessUnit == "" ? null : _BusinessUnit,
         );
         setState(() {
           _notEditing = true;

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -12,6 +12,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:connect_plus/services/web_api.dart';
 import 'package:connect_plus/services/auth_service/auth_service.dart';
 import 'package:connect_plus/injection_container.dart';
+import 'package:connect_plus/BusinessUnit.dart';
 
 class ProfilePage extends StatefulWidget {
   @override
@@ -39,6 +40,7 @@ class MapScreenState extends State<ProfilePage>
           phoneNumber: phoneController.text == "" ? null : phoneController.text,
           carPlate:
               carPlateController.text == "" ? null : carPlateController.text,
+          //businessUnit: businessUnitController
         );
         setState(() {
           _notEditing = true;
@@ -267,9 +269,6 @@ class MapScreenState extends State<ProfilePage>
                                                   carPlateController,
                                               initialValue: user.carPlate,
                                             ),
-                                      !_notEditing
-                                          ? _getActionButtons(user)
-                                          : new Container(),
                                     ],
                                   ));
                             },
@@ -508,5 +507,46 @@ class CarPlateTextField extends StatelessWidget {
         hintText: initialText,
       ),
     );
+  }
+}
+
+class BusinessUnitWidget extends StatelessWidget {
+  final void Function(String value) BusinessUnitController;
+  final void Function(bool value) asyncCallController;
+  final String userBu;
+  const BusinessUnitWidget({
+    Key key,
+    @required this.BusinessUnitController,
+    @required this.asyncCallController,
+    this.userBu,
+  }) : super(key: key);
+
+  void onChange(String val) {
+    //BusinessUnitController(val);
+  }
+
+  void onLoaded(bool val) {
+    asyncCallController(val);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+    return Padding(
+        padding: EdgeInsets.only(
+            left: width * 0.08, right: width * 0.08, top: height * 0.01),
+        child: Column(
+          children: [
+            Container(
+              width: width * 0.85,
+              child: BusinessUnit(
+                PassValue: onChange,
+                asyncCallController: onLoaded,
+                userBU: userBu,
+              ),
+            ),
+          ],
+        ));
   }
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -33,6 +33,7 @@ class User {
   Role role;
   String id;
   String carPlate;
+  String businessUnit;
 
   User({
     this.confirmed,
@@ -48,6 +49,7 @@ class User {
     this.role,
     this.id,
     this.carPlate,
+    this.businessUnit,
   });
 
   User.fromJson(Map<String, dynamic> json) {
@@ -64,6 +66,7 @@ class User {
     role = json['role'] != null ? new Role.fromJson(json['role']) : null;
     id = json['id'];
     carPlate = json['carPlate'];
+    businessUnit = json['businessUnit'];
   }
 
   Map<String, dynamic> toJson() {
@@ -83,6 +86,7 @@ class User {
       data['role'] = this.role.toJson();
     }
     data['id'] = this.id;
+    data['businessUnit'] = this.businessUnit;
     return data;
   }
 
@@ -100,22 +104,23 @@ class User {
     Role role,
     String id,
     String carPlate,
+    String businessUnit,
   }) {
     return User(
-      confirmed: confirmed ?? this.confirmed,
-      blocked: blocked ?? this.blocked,
-      sId: sId ?? this.sId,
-      username: username ?? this.username,
-      email: email ?? this.email,
-      phoneNumber: phoneNumber ?? this.phoneNumber,
-      provider: provider ?? this.provider,
-      createdAt: createdAt ?? this.createdAt,
-      updatedAt: updatedAt ?? this.updatedAt,
-      iV: iV ?? this.iV,
-      role: role ?? this.role,
-      id: id ?? this.id,
-      carPlate: carPlate ?? this.carPlate,
-    );
+        confirmed: confirmed ?? this.confirmed,
+        blocked: blocked ?? this.blocked,
+        sId: sId ?? this.sId,
+        username: username ?? this.username,
+        email: email ?? this.email,
+        phoneNumber: phoneNumber ?? this.phoneNumber,
+        provider: provider ?? this.provider,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
+        iV: iV ?? this.iV,
+        role: role ?? this.role,
+        id: id ?? this.id,
+        carPlate: carPlate ?? this.carPlate,
+        businessUnit: businessUnit ?? this.businessUnit);
   }
 }
 

--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -28,7 +28,6 @@ class _RegistrationState extends State<Registration> {
   final pwController = TextEditingController();
   final phoneController = TextEditingController();
   final carPlateController = TextEditingController();
-
   final algorithm = PBKDF2();
   var asyncCall = false;
   var ip;
@@ -37,6 +36,7 @@ class _RegistrationState extends State<Registration> {
   bool reloaded = false;
   TextStyle style = TextStyle(fontFamily: 'Montserrat', fontSize: 20.0);
   final _formKey = GlobalKey<FormState>();
+  String BusinessUnit;
   UserCredential userCredentials;
   void initState() {
     super.initState();
@@ -58,6 +58,10 @@ class _RegistrationState extends State<Registration> {
       if (_haveCar == false) carPlateController.clear();
       haveCar = _haveCar;
     });
+  }
+
+  void businessUnitController(String Value) {
+    BusinessUnit = Value;
   }
 
   @override
@@ -211,6 +215,7 @@ class _RegistrationState extends State<Registration> {
               username: fnController.text,
               phoneNumber: phoneController.text,
               carPlate: carPlateController.text,
+              businessUnit: BusinessUnit,
             );
             if (registered) {
               await successDialog();
@@ -296,7 +301,10 @@ class _RegistrationState extends State<Registration> {
                                     ),
                                     Container(
                                       width: width * 0.85,
-                                      child: BusinessUnitWidget(),
+                                      child: BusinessUnitWidget(
+                                        BusinessUnitController:
+                                            businessUnitController,
+                                      ),
                                     ),
                                     SizedBox(height: 20.0),
                                     Container(
@@ -665,10 +673,17 @@ class _State extends State<carRadioButton> {
 }
 
 class BusinessUnitWidget extends StatelessWidget {
-  String _value = "";
+  final void Function(String value) BusinessUnitController;
+
+  const BusinessUnitWidget({
+    Key key,
+    @required this.BusinessUnitController,
+  }) : super(key: key);
+
   void onChange(String val) {
-    _value = val;
-    print(_value);
+    // _value = val;
+    BusinessUnitController(val);
+    print(val);
   }
 
   @override

--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -10,6 +10,7 @@ import 'package:localstorage/localstorage.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:connect_plus/services/auth_service/auth_service.dart';
 import 'package:connect_plus/injection_container.dart';
+import 'package:connect_plus/BusinessUnit.dart';
 
 class Registration extends StatefulWidget {
   Registration({Key key, this.title}) : super(key: key);
@@ -27,6 +28,7 @@ class _RegistrationState extends State<Registration> {
   final pwController = TextEditingController();
   final phoneController = TextEditingController();
   final carPlateController = TextEditingController();
+
   final algorithm = PBKDF2();
   var asyncCall = false;
   var ip;
@@ -292,6 +294,11 @@ class _RegistrationState extends State<Registration> {
                                       width: width * 0.85,
                                       child: phoneField,
                                     ),
+                                    Container(
+                                      width: width * 0.85,
+                                      child: BusinessUnitWidget(),
+                                    ),
+                                    SizedBox(height: 20.0),
                                     Container(
                                       width: width * 0.85,
                                       child: carRadioButton(
@@ -653,6 +660,37 @@ class _State extends State<carRadioButton> {
               )
             ])
           ]),
+    );
+  }
+}
+
+class BusinessUnitWidget extends StatelessWidget {
+  String _value = "";
+  void onChange(String val) {
+    _value = val;
+    print(_value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    return Column(
+      children: [
+        SizedBox(height: 20.0),
+        Container(
+          width: width * 0.85,
+          child: Text(
+            'Business Unit',
+            style: TextStyle(fontSize: 20.0),
+          ),
+        ),
+        Container(
+          width: width * 0.85,
+          child: BusinessUnit(
+            PassValue: onChange,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -36,7 +36,7 @@ class _RegistrationState extends State<Registration> {
   bool reloaded = false;
   TextStyle style = TextStyle(fontFamily: 'Montserrat', fontSize: 20.0);
   final _formKey = GlobalKey<FormState>();
-  String BusinessUnit;
+  String BusinessUnit = "";
   UserCredential userCredentials;
   void initState() {
     super.initState();

--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -64,6 +64,13 @@ class _RegistrationState extends State<Registration> {
     BusinessUnit = Value;
   }
 
+  void _asyncCallController(bool value) {
+    print(value);
+    setState(() {
+      asyncCall = value;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     var width = MediaQuery.of(context).size.width;
@@ -304,6 +311,8 @@ class _RegistrationState extends State<Registration> {
                                       child: BusinessUnitWidget(
                                         BusinessUnitController:
                                             businessUnitController,
+                                        asyncCallController:
+                                            _asyncCallController,
                                       ),
                                     ),
                                     SizedBox(height: 20.0),
@@ -674,16 +683,19 @@ class _State extends State<carRadioButton> {
 
 class BusinessUnitWidget extends StatelessWidget {
   final void Function(String value) BusinessUnitController;
-
+  final void Function(bool value) asyncCallController;
   const BusinessUnitWidget({
     Key key,
     @required this.BusinessUnitController,
+    @required this.asyncCallController,
   }) : super(key: key);
 
   void onChange(String val) {
-    // _value = val;
     BusinessUnitController(val);
-    print(val);
+  }
+
+  void onLoaded(bool val) {
+    asyncCallController(val);
   }
 
   @override
@@ -703,6 +715,7 @@ class BusinessUnitWidget extends StatelessWidget {
           width: width * 0.85,
           child: BusinessUnit(
             PassValue: onChange,
+            asyncCallController: onLoaded,
           ),
         ),
       ],

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -25,6 +25,7 @@ class AuthService {
     @required String username,
     @required String phoneNumber,
     String carPlate,
+    String businessUnit,
   }) async {
     try {
       final UserCredential cred = await _fbAuth.createUserWithEmailAndPassword(
@@ -43,6 +44,7 @@ class AuthService {
           'updatedAt': DateTime.now().toString(),
           'blocked': false,
           'id': cred.user.uid,
+          'businessUnit': businessUnit,
         });
         return true;
       }

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -77,16 +77,17 @@ class AuthService {
     }
   }
 
-  Future<void> updateProfile({
-    String username,
-    String phoneNumber,
-    String carPlate,
-  }) async {
+  Future<void> updateProfile(
+      {String username,
+      String phoneNumber,
+      String carPlate,
+      String businessUnit}) async {
     final userUid = _fbAuth.currentUser.uid;
     await _fs.collection('users').doc(userUid).update({
       'username': username ?? _user.username,
       'phoneNumber': phoneNumber ?? _user.phoneNumber,
       'carPlate': carPlate ?? _user.carPlate,
+      'businessUnit': businessUnit ?? _user.businessUnit,
     });
     _user = _user.copyWith(
       username: username,

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -90,10 +90,10 @@ class AuthService {
       'businessUnit': businessUnit ?? _user.businessUnit,
     });
     _user = _user.copyWith(
-      username: username,
-      phoneNumber: phoneNumber,
-      carPlate: carPlate,
-    );
+        username: username,
+        phoneNumber: phoneNumber,
+        carPlate: carPlate,
+        businessUnit: businessUnit);
   }
 
   Future<user_model.User> get user async {

--- a/lib/services/web_api.dart
+++ b/lib/services/web_api.dart
@@ -35,7 +35,7 @@ class WebAPI {
   static final String _categoriesURL = '/categories';
   static final String _eventHighlightsURL = "/event-highlights";
   static final String _announcementURL = "/announcements";
-
+  static final String _businessUnitURL = "/business-units";
   // TODO: remove this to a separate service
   static User currentUser;
   static String currentToken;
@@ -504,5 +504,18 @@ class WebAPI {
     }
 
     return announcements;
+  }
+
+  static Future<List<String>> getBusinessUnits() async {
+    final response = await get(_businessUnitURL);
+
+    // TODO: Add this logic to a seperate transformer service
+    final List<dynamic> rawBU = json.decode(response.body);
+    final List<String> BUs = [];
+    for (final BU in rawBU) {
+      BUs.add(BU["name"]);
+    }
+    print(BUs);
+    return BUs;
   }
 }


### PR DESCRIPTION
Added the option to edit business unit in profile.

## Logic
1. Business unit is displayed in a text field
2. onClick edit button the business units are fetched from the backend and the user can choose the business unit from drop down menu 
3. loading image 'rotating logo' appears until all Business units are fetched, it usually takes ~1 second, but I've added it for better user experience, as without it the dropdown will not appear until all values are fetched.
## demo
<img src="https://user-images.githubusercontent.com/33899216/118632997-46df0180-b7d1-11eb-8489-719be67fc096.gif" width="360">


