### PR TITLE
Bugfix 178448321 no option to add car plate in profile

### DIFF
--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -536,17 +536,18 @@ class _EditingCarPlatesListState extends State<EditingCarPlatesList> {
               padding: const EdgeInsets.only(top: 12.0),
               child: Row(
                 children: [
-                  Container(
-                    width: MediaQuery.of(context).size.width * 0.8,
-                    child: CarPlatePicker(
-                      key: ObjectKey(
-                        plate, // prevents incorrect plate being deleted
+                  Expanded(
+                    child: Container(
+                      child: CarPlatePicker(
+                        key: ObjectKey(
+                          plate, // prevents incorrect plate being deleted
+                        ),
+                        editable: true,
+                        initialPlate: plate,
+                        onChanged: (plate) {
+                          changePlate(index, plate);
+                        },
                       ),
-                      editable: true,
-                      initialPlate: plate,
-                      onChanged: (plate) {
-                        changePlate(index, plate);
-                      },
                     ),
                   ),
                   FloatingActionButton(

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -278,12 +278,16 @@ class MapScreenState extends State<ProfilePage>
                                       _getLabel("Car Plate"),
                                       user.carPlates.isEmpty && _notEditing
                                           ? NoCarsText()
-                                          : CarPlatesList(
-                                              initialPlates: user.carPlates,
-                                              onChanged: (plates) {
-                                                _carPlates = plates;
-                                              },
-                                            ),
+                                          : _notEditing
+                                              ? CarPlatesList(
+                                                  carPlates: user.carPlates,
+                                                )
+                                              : EditingCarPlatesList(
+                                                  initialPlates: user.carPlates,
+                                                  onChanged: (plates) {
+                                                    _carPlates = plates;
+                                                  },
+                                                ),
                                       _getLabel("Business Unit"),
                                       _notEditing
                                           ? _getField(
@@ -460,26 +464,52 @@ class NoCarsText extends StatelessWidget {
   }
 }
 
-class CarPlatesList extends StatefulWidget {
-  final List<String> initialPlates;
-  final Function(List<String> plate) onChanged;
-  final bool isEditing;
+class CarPlatesList extends StatelessWidget {
+  final List<String> carPlates;
   const CarPlatesList({
     Key key,
-    this.initialPlates,
-    @required this.onChanged,
-    this.isEditing = true,
+    @required this.carPlates,
   }) : super(key: key);
 
   @override
-  _CarPlatesListState createState() => _CarPlatesListState();
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: NeverScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 24),
+      shrinkWrap: true,
+      children: carPlates.map((plate) {
+        return Padding(
+          padding: const EdgeInsets.only(top: 12.0),
+          child: CarPlatePicker(
+            editable: false,
+            initialPlate: plate,
+            onChanged: (_) {},
+          ),
+        );
+      }).toList(),
+    );
+  }
 }
 
-class _CarPlatesListState extends State<CarPlatesList> {
+class EditingCarPlatesList extends StatefulWidget {
+  final List<String> initialPlates;
+  final Function(List<String> plate) onChanged;
+  const EditingCarPlatesList({
+    Key key,
+    this.initialPlates,
+    @required this.onChanged,
+  }) : super(key: key);
+
+  @override
+  _EditingCarPlatesListState createState() => _EditingCarPlatesListState();
+}
+
+class _EditingCarPlatesListState extends State<EditingCarPlatesList> {
   List<String> carPlates;
   @override
   void initState() {
-    carPlates = widget.initialPlates;
+    carPlates = [];
+    carPlates.addAll(widget.initialPlates); // deep copy
     super.initState();
   }
 
@@ -489,6 +519,7 @@ class _CarPlatesListState extends State<CarPlatesList> {
     } else {
       carPlates[index] = plate;
     }
+    widget.onChanged(carPlates);
   }
 
   @override
@@ -511,7 +542,7 @@ class _CarPlatesListState extends State<CarPlatesList> {
                       key: ObjectKey(
                         plate, // prevents incorrect plate being deleted
                       ),
-                      editable: widget.isEditing,
+                      editable: true,
                       initialPlate: plate,
                       onChanged: (plate) {
                         changePlate(index, plate);

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -208,7 +208,8 @@ class MapScreenState extends State<ProfilePage>
                                     decoration: new BoxDecoration(
                                       image: new DecorationImage(
                                         image: new ExactAssetImage(
-                                            'assets/as.png'),
+                                          'assets/as.png',
+                                        ),
                                         fit: BoxFit.contain,
                                       ),
                                     )),
@@ -275,35 +276,14 @@ class MapScreenState extends State<ProfilePage>
                                       _getField(user.phoneNumber.toString(),
                                           phoneController, false),
                                       _getLabel("Car Plate"),
-                                      user.carPlates.length != 0
-                                          ? ListView.separated(
-                                              separatorBuilder:
-                                                  (context, index) => Divider(
-                                                        color: Colors.white,
-                                                      ),
-                                              shrinkWrap: true,
-                                              itemCount: user.carPlates.length,
-                                              itemBuilder:
-                                                  (BuildContext context,
-                                                      int index) {
-                                                return Padding(
-                                                  padding: const EdgeInsets
-                                                          .symmetric(
-                                                      horizontal: 32,
-                                                      vertical: 12),
-                                                  child: CarPlatePicker(
-                                                    initialPlate: user
-                                                            .carPlates[index] ??
-                                                        user.carPlates[index],
-                                                    onChanged: (plate) {
-                                                      user.carPlates[index] =
-                                                          plate;
-                                                    },
-                                                    editable: !_notEditing,
-                                                  ),
-                                                );
-                                              })
-                                          : Container(),
+                                      user.carPlates.isEmpty && _notEditing
+                                          ? NoCarsText()
+                                          : CarPlatesList(
+                                              initialPlates: user.carPlates,
+                                              onChanged: (plates) {
+                                                _carPlates = plates;
+                                              },
+                                            ),
                                       _getLabel("Business Unit"),
                                       _notEditing
                                           ? _getField(
@@ -598,5 +578,129 @@ class BusinessUnitWidget extends StatelessWidget {
             ),
           ],
         ));
+  }
+}
+
+class NoCarsText extends StatelessWidget {
+  const NoCarsText({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        top: 12,
+        left: MediaQuery.of(context).size.width * 0.08,
+      ),
+      child: Text(
+        "No cars registered",
+        style: TextStyle(color: Theme.of(context).disabledColor),
+      ),
+    );
+  }
+}
+
+class CarPlatesList extends StatefulWidget {
+  final List<String> initialPlates;
+  final Function(List<String> plate) onChanged;
+  final bool isEditing;
+  const CarPlatesList({
+    Key key,
+    this.initialPlates,
+    @required this.onChanged,
+    this.isEditing = true,
+  }) : super(key: key);
+
+  @override
+  _CarPlatesListState createState() => _CarPlatesListState();
+}
+
+class _CarPlatesListState extends State<CarPlatesList> {
+  List<String> carPlates;
+  num numberOfCarPlates;
+  @override
+  void initState() {
+    carPlates = widget.initialPlates;
+    numberOfCarPlates = widget.initialPlates.length;
+    super.initState();
+  }
+
+  String _initialPlate(index) {
+    if (widget.initialPlates.length - 1 > index) {
+      return widget.initialPlates[index];
+    }
+    return null;
+  }
+
+  void changePlate(index, plate) {
+    if (index > carPlates.length - 1) {
+      carPlates.add(plate);
+    } else {
+      carPlates[index] = plate;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ListView.builder(
+          physics: NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.only(top: 12, left: 24),
+          shrinkWrap: true,
+          itemCount: numberOfCarPlates,
+          itemBuilder: (context, index) {
+            return Padding(
+              padding: const EdgeInsets.only(top: 12.0),
+              child: Row(
+                children: [
+                  Container(
+                    width: MediaQuery.of(context).size.width * 0.8,
+                    child: CarPlatePicker(
+                      editable: widget.isEditing,
+                      initialPlate: _initialPlate(index),
+                      onChanged: (plate) {
+                        changePlate(index, plate);
+                      },
+                    ),
+                  ),
+                  FloatingActionButton(
+                    backgroundColor: Colors.transparent,
+                    elevation: 0,
+                    child: Icon(
+                      Icons.delete,
+                      color: Colors.grey,
+                      size: 30,
+                    ),
+                    onPressed: () {
+                      setState(() {
+                        numberOfCarPlates--;
+                        carPlates.removeAt(index);
+                      });
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+        Visibility(
+          visible: numberOfCarPlates < 2,
+          child: FloatingActionButton(
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            onPressed: () {
+              setState(() {
+                numberOfCarPlates++;
+              });
+            },
+            child: Icon(
+              Icons.add,
+              color: Colors.grey,
+              size: 30,
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -67,7 +67,7 @@ class User {
     iV = json['__v'];
     role = json['role'] != null ? new Role.fromJson(json['role']) : null;
     id = json['id'];
-    carPlates = json['carPlates'] ?? [];
+    carPlates = List<String>.from(json['carPlates']) ?? [];
     businessUnit = json['businessUnit'];
     pushNotificationToken = json['pushNotificationToken'];
   }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -53,13 +53,6 @@ class User {
     this.businessUnit,
     this.pushNotificationToken,
   });
-  void addCarplates(List<dynamic> _carPlates) {
-    carPlates = new List<String>();
-    for (final carplate in _carPlates) {
-      carPlates.add(carplate.toString());
-    }
-    return;
-  }
 
   User.fromJson(Map<String, dynamic> json) {
     confirmed = json['confirmed'];
@@ -74,7 +67,7 @@ class User {
     iV = json['__v'];
     role = json['role'] != null ? new Role.fromJson(json['role']) : null;
     id = json['id'];
-    addCarplates(json['carPlates']);
+    carPlates = json['carPlates'] ?? [];
     businessUnit = json['businessUnit'];
     pushNotificationToken = json['pushNotificationToken'];
   }

--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -330,44 +330,11 @@ class _RegistrationState extends State<Registration> {
                                     ),
                                   ),
                                   haveCar == true
-                                      ? Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.center,
-                                          children: <Widget>[
-                                              ListView.separated(
-                                                  separatorBuilder:
-                                                      (context, index) =>
-                                                          Divider(
-                                                            color: Colors.white,
-                                                          ),
-                                                  shrinkWrap: true,
-                                                  itemCount: carPlates.length,
-                                                  itemBuilder:
-                                                      (BuildContext context,
-                                                          int index) {
-                                                    return Container(
-                                                        width: width * 0.85,
-                                                        child: CarPlateForm(
-                                                          onChanged: (plate) {
-                                                            carPlates[index] =
-                                                                plate;
-                                                          },
-                                                        ));
-                                                  }),
-                                              SizedBox(height: height * 0.027),
-                                              addCarPlateButton(
-                                                add: () {
-                                                  setState(() {
-                                                    carPlates.add("");
-                                                  });
-                                                },
-                                                delete: () {
-                                                  setState(() {
-                                                    carPlates.removeLast();
-                                                  });
-                                                },
-                                              )
-                                            ])
+                                      ? CarPlatesList(
+                                          onChanged: (plates) {
+                                            carPlates = plates;
+                                          },
+                                        )
                                       : Container(),
                                   SizedBox(height: height * 0.027),
                                   Container(
@@ -662,69 +629,99 @@ class BusinessUnitWidget extends StatelessWidget {
   }
 }
 
-class addCarPlateButton extends StatefulWidget {
-  final Function() add;
-  final Function() delete;
-  const addCarPlateButton({Key key, @required this.add, @required this.delete})
-      : super(key: key);
+class CarPlatesList extends StatefulWidget {
+  final List<String> initialPlates;
+  final Function(List<String> plate) onChanged;
+  const CarPlatesList({
+    Key key,
+    this.initialPlates,
+    @required this.onChanged,
+  }) : super(key: key);
+
   @override
-  _addCarPlateButtonState createState() => _addCarPlateButtonState();
+  _CarPlatesListState createState() => _CarPlatesListState();
 }
 
-class _addCarPlateButtonState extends State<addCarPlateButton> {
-  bool addBool = true;
-  Color color = Color.fromRGBO(255, 255, 255, 50);
+class _CarPlatesListState extends State<CarPlatesList> {
+  List<String> carPlates = [];
+
+  void changePlate(index, plate) {
+    if (index > carPlates.length - 1) {
+      carPlates.add(plate);
+    } else {
+      carPlates[index] = plate;
+    }
+    widget.onChanged(carPlates);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    var width = MediaQuery.of(context).size.width;
-    var height = MediaQuery.of(context).size.height;
-    TextStyle style = TextStyle(fontFamily: 'Montserrat', fontSize: 20.0);
-    @override
-    void initState() {
-      super.initState();
-      setState(() {
-        addBool = true;
-      });
-    }
-
-    void _update() {
-      setState(() {
-        if (addBool == true) {
-          addBool = false;
-          color = Color.fromRGBO(255, 255, 255, 100);
-        } else {
-          addBool = true;
-          color = Color.fromRGBO(255, 255, 255, 50);
-        }
-      });
-    }
-
-    return Container(
-      decoration: BoxDecoration(
-        //border: Border.all(color: Color.fromRGBO(201, 201, 201, 100)),
-        borderRadius: BorderRadius.circular(25.0),
-        border: Border.all(
-          color: Colors.grey,
-        ),
-        color: color,
-      ),
-      child: MaterialButton(
-        //minWidth: MediaQuery.of(context).size.width,
-        padding: EdgeInsets.fromLTRB(
-            width * 0.02, height * 0.023, width * 0.02, height * 0.023),
-        onPressed: () {
-          (addBool == true) ? widget.add() : widget.delete();
-          _update();
-        },
-        child: (addBool == true)
-            ? Icon(
-                Icons.add_box,
-                color: Colors.grey,
-              )
-            : Icon(
-                Icons.delete,
-                color: Colors.grey,
+    return Column(
+      children: [
+        ListView(
+          physics: NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          shrinkWrap: true,
+          children: carPlates.map((plate) {
+            int index = carPlates.indexOf(plate);
+            return Padding(
+              padding: const EdgeInsets.only(top: 12.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: CarPlatePicker(
+                      key: ObjectKey(
+                        plate, // prevents incorrect plate being deleted
+                      ),
+                      editable: true,
+                      initialPlate: plate,
+                      onChanged: (plate) {
+                        changePlate(index, plate);
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: carPlates.length > 1,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 4),
+                      child: InkWell(
+                        child: Icon(
+                          Icons.delete,
+                          color: Colors.grey,
+                          size: 30,
+                        ),
+                        onTap: () {
+                          setState(() {
+                            carPlates.removeAt(index);
+                          });
+                        },
+                      ),
+                    ),
+                  ),
+                ],
               ),
-      ),
+            );
+          }).toList(),
+        ),
+        Visibility(
+          visible: carPlates.length < 2,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: InkWell(
+              onTap: () {
+                setState(() {
+                  carPlates.add('');
+                });
+              },
+              child: Icon(
+                Icons.add,
+                color: Colors.grey,
+                size: 30,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/registration.dart
+++ b/lib/registration.dart
@@ -465,25 +465,6 @@ class _RegistrationState extends State<Registration> {
   }
 }
 
-class CarPlateForm extends StatelessWidget {
-  final Function(String) onChanged;
-
-  const CarPlateForm({Key key, @required this.onChanged}) : super(key: key);
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        CarPlateInputTitle(),
-        SizedBox(height: 10),
-        CarPlatePicker(
-          onChanged: onChanged,
-        ),
-      ],
-    );
-  }
-}
-
 class CarPlateInputTitle extends StatelessWidget {
   CarPlateInputTitle({
     Key key,
@@ -643,7 +624,7 @@ class CarPlatesList extends StatefulWidget {
 }
 
 class _CarPlatesListState extends State<CarPlatesList> {
-  List<String> carPlates = [];
+  List<String> carPlates = [""];
 
   void changePlate(index, plate) {
     if (index > carPlates.length - 1) {
@@ -658,6 +639,7 @@ class _CarPlatesListState extends State<CarPlatesList> {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        CarPlateInputTitle(),
         ListView(
           physics: NeverScrollableScrollPhysics(),
           padding: const EdgeInsets.symmetric(horizontal: 4),

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -97,6 +97,7 @@ class AuthService {
       'businessUnit': businessUnit ?? _user.businessUnit,
       'pushNotificationToken':
           pushNotificationToken ?? _user.pushNotificationToken,
+      'updatedAt': DateTime.now().toString(),
     });
     _user = _user.copyWith(
       username: username,

--- a/lib/widgets/car_plate_widget.dart
+++ b/lib/widgets/car_plate_widget.dart
@@ -446,7 +446,7 @@ class _CarPlateScrollColumnState extends State<CarPlateScrollColumn> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 28,
+      width: 36,
       height: 120,
       child: widget.editable
           ? PageView.builder(

--- a/lib/widgets/car_plate_widget.dart
+++ b/lib/widgets/car_plate_widget.dart
@@ -200,7 +200,7 @@ class _CarPlateLettersState extends State<CarPlateLetters> {
       if (widget.initialLetters.length == 2) {
         if (position == 2) {
           return null;
-        } else if (position == 1) {
+        } else {
           return widget.initialLetters[position];
         }
       } else if (widget.initialLetters.length == 3) {
@@ -208,6 +208,14 @@ class _CarPlateLettersState extends State<CarPlateLetters> {
       }
     }
     return null;
+  }
+
+  void _onChanged() {
+    String letters = "";
+    if (_char1 != null) letters += _char1;
+    if (_char2 != null) letters += _char2;
+    if (_char3 != null) letters += _char3;
+    widget.onChanged(letters);
   }
 
   @override
@@ -226,7 +234,7 @@ class _CarPlateLettersState extends State<CarPlateLetters> {
           onChanged: (character) {
             _char3 = character;
             // characters are switched as arabic switched alignments
-            widget.onChanged('$_char1$_char2$_char3');
+            _onChanged();
           },
         ),
         CarPlateScrollColumn(
@@ -235,7 +243,7 @@ class _CarPlateLettersState extends State<CarPlateLetters> {
           initialItem: _getInitialLetterAt(1),
           onChanged: (character) {
             _char2 = character;
-            widget.onChanged('$_char1$_char2$_char3');
+            _onChanged();
           },
         ),
         CarPlateScrollColumn(
@@ -244,7 +252,7 @@ class _CarPlateLettersState extends State<CarPlateLetters> {
           initialItem: _getInitialLetterAt(0),
           onChanged: (character) {
             _char1 = character;
-            widget.onChanged('$_char1$_char2$_char3');
+            _onChanged();
           },
         ),
         // SizedBox(
@@ -292,6 +300,15 @@ class _CarPlateNumbersState extends State<CarPlateNumbers> {
     return null;
   }
 
+  void _onChanged() {
+    String nums = "";
+    if (_no1 != null) nums += _no1;
+    if (_no2 != null) nums += _no2;
+    if (_no3 != null) nums += _no3;
+    if (_no4 != null) nums += _no4;
+    widget.onChanged(nums);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -304,7 +321,7 @@ class _CarPlateNumbersState extends State<CarPlateNumbers> {
           initialItem: _getInitialNumberAt(0),
           onChanged: (number) {
             _no1 = number;
-            widget.onChanged("$_no1$_no2$_no3$_no4");
+            _onChanged();
           },
         ),
         CarPlateScrollColumn(
@@ -313,7 +330,7 @@ class _CarPlateNumbersState extends State<CarPlateNumbers> {
           initialItem: _getInitialNumberAt(1),
           onChanged: (number) {
             _no2 = number;
-            widget.onChanged("$_no1$_no2$_no3$_no4");
+            _onChanged();
           },
         ),
         CarPlateScrollColumn(
@@ -322,7 +339,7 @@ class _CarPlateNumbersState extends State<CarPlateNumbers> {
           initialItem: _getInitialNumberAt(2),
           onChanged: (number) {
             _no3 = number;
-            widget.onChanged("$_no1$_no2$_no3$_no4");
+            _onChanged();
           },
         ),
         CarPlateScrollColumn(
@@ -331,7 +348,7 @@ class _CarPlateNumbersState extends State<CarPlateNumbers> {
           initialItem: _getInitialNumberAt(3),
           onChanged: (number) {
             _no4 = number;
-            widget.onChanged("$_no1$_no2$_no3$_no4");
+            _onChanged();
           },
         ),
       ],


### PR DESCRIPTION
## Initial Bug
If a user initially registers without adding any car plates and selecting the "No Cars" option, then they would not have the ability to add a car from the profile screen.

## Changes
- [x] Add a "+" button to the car plates section when editing a profile with only one car plate or none
- [x] Add logic and design to remove specific car plates while registering or editing in the profile screen
- [x] Fix `CarPlatesPicker` from firing up `onChanged` callback multiple times on one change
- [x] Add concatenation so that when a user leaves an empty number in the middle like `أب  ١٣   ٤` it is changed to `أب  ٤١٣`

## Screenshot
### Registration
![newcarplreg](https://user-images.githubusercontent.com/41022464/121878801-69026b80-cd0c-11eb-8c90-1a9feb0ce079.gif)

### Profile
![newcarpl](https://user-images.githubusercontent.com/41022464/121878818-6ef84c80-cd0c-11eb-8586-60ac376d176c.gif)



