### PR TITLE
Bugfix 178537151 render overflow in webinar tile

### DIFF
--- a/lib/EventsVariable.dart
+++ b/lib/EventsVariable.dart
@@ -197,8 +197,14 @@ class Single_Event extends StatelessWidget {
                     color: Colors.white70,
                     child: ListTile(
                       title: Column(children: <Widget>[
-                        Text(event.name,
-                            style: TextStyle(fontWeight: FontWeight.bold)),
+                        Text(
+                          event.name,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
                         Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[

--- a/lib/OfferWidget.dart
+++ b/lib/OfferWidget.dart
@@ -119,6 +119,7 @@ class _OfferState extends State<OfferWidget> with TickerProviderStateMixin {
                               child: Text(
                                 offer.name,
                                 textAlign: TextAlign.center,
+                                overflow: TextOverflow.ellipsis,
                                 style: TextStyle(
                                     fontSize: size * 30, color: Colors.black87),
                               ),

--- a/lib/Profile.dart
+++ b/lib/Profile.dart
@@ -572,18 +572,22 @@ class _EditingCarPlatesListState extends State<EditingCarPlatesList> {
         ),
         Visibility(
           visible: carPlates.length < 2,
-          child: FloatingActionButton(
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            onPressed: () {
+          child: InkWell(
+            onTap: () {
               setState(() {
                 carPlates.add('');
               });
             },
-            child: Icon(
-              Icons.add,
-              color: Colors.grey,
-              size: 30,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 10, bottom: 20),
+              child: Text.rich(TextSpan(
+                  text: "+ Add another car plate",
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                    color: Colors.grey,
+                    fontFamily: "Roboto",
+                  ))),
             ),
           ),
         ),

--- a/lib/WebinarWidget.dart
+++ b/lib/WebinarWidget.dart
@@ -91,8 +91,11 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
                     child: Text(
                       ergwebinar.name,
                       textAlign: TextAlign.center,
-                      style:
-                          TextStyle(fontSize: size * 35, color: Utils.header),
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: size * 35,
+                        color: Utils.header,
+                      ),
                     ),
                   )
                 ],

--- a/lib/WebinarWidget.dart
+++ b/lib/WebinarWidget.dart
@@ -187,16 +187,18 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
                   fontSize: size * 39,
                   textcolor: Utils.header)),
           Padding(
-              padding: EdgeInsets.fromLTRB(0, 0, width * 0.02, height * 0.02),
-              child: SizedBox(
-                  height: height * 0.25,
-                  child: ListView(
-                    controller: _scrollController,
-                    physics: ClampingScrollPhysics(),
-                    shrinkWrap: true,
-                    scrollDirection: Axis.horizontal,
-                    children: webinarsByERG(),
-                  ))),
+            padding: EdgeInsets.fromLTRB(0, 0, width * 0.02, height * 0.02),
+            child: SizedBox(
+              height: height * 0.25,
+              child: ListView(
+                controller: _scrollController,
+                physics: ClampingScrollPhysics(),
+                shrinkWrap: true,
+                scrollDirection: Axis.horizontal,
+                children: webinarsByERG(),
+              ),
+            ),
+          ),
         ],
       );
     } else {

--- a/lib/WebinarWidget.dart
+++ b/lib/WebinarWidget.dart
@@ -93,7 +93,7 @@ class _WebinarState extends State<WebinarWidget> with TickerProviderStateMixin {
                       textAlign: TextAlign.center,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        fontSize: size * 35,
+                        fontSize: 16,
                         color: Utils.header,
                       ),
                     ),


### PR DESCRIPTION
## Description
Fix render overflow in webinar screen under (Webinars by ...), as well as the same occurrence in offers and events.

## Screenshots
### Webinar
<img src=https://user-images.githubusercontent.com/41022464/122389540-53da4680-cf71-11eb-8433-00efa956c279.png width=300px>

### Homepage Events and Webinars
#### Before
<img src=https://user-images.githubusercontent.com/41022464/122389644-6eacbb00-cf71-11eb-89d2-78af471f2776.png width=300px>

#### After

<img src=https://user-images.githubusercontent.com/41022464/122389683-78362300-cf71-11eb-95e0-be0376bc8a31.png width=300px>